### PR TITLE
fix: don't push the mfe image to docker.io

### DIFF
--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -41,9 +41,6 @@ hooks = {
     "build-image": {
         "mfe": "{{ MFE_DOCKER_IMAGE }}",
     },
-    "remote-image": {
-        "mfe": "{{ MFE_DOCKER_IMAGE }}",
-    },
     "init": ["lms"],
 }
 


### PR DESCRIPTION
The openedx-mfe Docker image should be re-built by every user. If we push the
image to docker.io, people are at risk of actually downloading it, and it will
simply not work for them.

This is ready for review @overhangio/tutor-developers.