### PR TITLE
Added MFE service (patch nginx-extra)

### DIFF
--- a/tutormfe/patches/nginx-extra
+++ b/tutormfe/patches/nginx-extra
@@ -1,0 +1,19 @@
+# MFE service
+upstream mfe-backend {
+    server mfe:8002 fail_timeout=0;
+}
+server {
+    listen 80;
+    server_name {{ MFE_HOST }};
+
+    # Disables server version feedback on pages and in headers
+    server_tokens off;
+
+    client_max_body_size 10m;
+
+    location / {
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_pass http://mfe-backend;
+    }
+}

--- a/tutormfe/patches/nginx-extra
+++ b/tutormfe/patches/nginx-extra
@@ -3,17 +3,17 @@ upstream mfe-backend {
     server mfe:8002 fail_timeout=0;
 }
 server {
-    listen 80;
-    server_name {{ MFE_HOST }};
+  listen 80;
+  server_name {{ MFE_HOST }};
 
-    # Disables server version feedback on pages and in headers
-    server_tokens off;
+  # Disables server version feedback on pages and in headers
+  server_tokens off;
 
-    client_max_body_size 10m;
+  client_max_body_size 10m;
 
-    location / {
+  location / {
     proxy_set_header Host $http_host;
     proxy_redirect off;
     proxy_pass http://mfe-backend;
-    }
+  }
 }


### PR DESCRIPTION
Added MFE service in patch nginx-extra, so a reverse proxy has access to the micro frontends on {{ MFE_HOST }}