### PR TITLE
fix: MFE service unavailable behind custom host proxy

### DIFF
--- a/tutormfe/patches/caddyfile
+++ b/tutormfe/patches/caddyfile
@@ -1,6 +1,3 @@
 {{ MFE_HOST }}{% if not ENABLE_HTTPS %}:80{% endif %} {
-    handle / {
-        respond 204
-    }
-    reverse_proxy mfe:8002
+    reverse_proxy nginx:80
 }

--- a/tutormfe/patches/nginx-extra
+++ b/tutormfe/patches/nginx-extra
@@ -1,0 +1,24 @@
+# MFE service
+upstream mfe-backend {
+    server mfe:8002 fail_timeout=0;
+}
+server {
+  listen 80;
+  server_name {{ MFE_HOST }};
+
+  # Disables server version feedback on pages and in headers
+  server_tokens off;
+
+  # We should not have to post much data to the MFE server
+  client_max_body_size 2m;
+
+  location = / {
+    return 204;
+  }
+
+  location / {
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_pass http://mfe-backend;
+  }
+}


### PR DESCRIPTION
The MFE service was running directly behind Caddy, and not Nginx. Thus, when
Caddy was disabled (RUN_CADDY=false), the MFE service was unavailable. To
address this, we include nginx as an extra proxy between Caddy and the MFE.
Caddy should only take care of SSL termination, as for other services.

Close #6.

This is ready for review @overhangio/tutor-developers. Cc @insad who opened the initial PR: https://github.com/overhangio/tutor-mfe/pull/7