### PR TITLE
docs: clarify profile MFE uninstallation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,7 @@ You will also have to manually remove a few waffle flags::
 
     tutor local run lms ./manage.py lms waffle_delete --flags account.redirect_to_microfrontend
     tutor local run lms ./manage.py lms waffle_delete --flags learner_profile.redirect_to_microfrontend
+    tutor local run lms site-configuration unset ENABLE_PROFILE_MICROFRONTEND
 
 License
 -------


### PR DESCRIPTION
If the ENABLE_PROFILE_MICROFRONTEND site configuration is not removed, the LMS
shows 500 errors everywhere.

This is ready for review @overhangio/tutor-developers.