### PR TITLE
fix: swap Learning MFE name and port for LEARNING_MICROFRONTEND_URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Learning
 ~~~~~~~~
 
 .. image:: https://raw.githubusercontent.com/overhangio/tutor-mfe/master/screenshots/learning.png
-    :alt: Gradebook MFE screenshot
+    :alt: Learning MFE screenshot
 
 The Learning MFE replaces the former courseware, which is the core part of the LMS where students follow courses.
 

--- a/tutormfe/patches/openedx-lms-development-settings
+++ b/tutormfe/patches/openedx-lms-development-settings
@@ -5,7 +5,7 @@ ACCOUNT_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ MFE_ACCOUNT_MFE_APP["port"
 WRITABLE_GRADEBOOK_URL = "http://{{ MFE_HOST }}:{{ MFE_GRADEBOOK_MFE_APP["port"] }}/{{ MFE_GRADEBOOK_MFE_APP["name"] }}"
 {% endif %}
 {% if MFE_LEARNING_MFE_APP %}
-LEARNING_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/{{ MFE_LEARNING_MFE_APP["name"] }}:{{ MFE_LEARNING_MFE_APP["port"] }}"
+LEARNING_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}:{{ MFE_LEARNING_MFE_APP["port"] }}/{{ MFE_LEARNING_MFE_APP["name"] }}"
 {% endif %}
 {% if MFE_PROFILE_MFE_APP %}
 PROFILE_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}:{{ MFE_PROFILE_MFE_APP["port"] }}/{{ MFE_PROFILE_MFE_APP["name"] }}/u/"

--- a/tutormfe/templates/mfe/hooks/lms/init
+++ b/tutormfe/templates/mfe/hooks/lms/init
@@ -11,9 +11,3 @@ site-configuration set ENABLE_PROFILE_MICROFRONTEND true
 site-configuration unset ENABLE_PROFILE_MICROFRONTEND
 ./manage.py lms waffle_delete --flags learner_profile.redirect_to_microfrontend
 {% endif %}
-
-{% if MFE_LEARNING_MFE_APP %}
-(./manage.py lms waffle_flag --list | grep courseware.courseware_mfe) || ./manage.py lms waffle_flag --create --everyone courseware.courseware_mfe
-{% else %}
-./manage.py lms waffle_delete --flags courseware.courseware_mfe
-{% endif %}


### PR DESCRIPTION
Changes:
- fix LEARNING_MICROFRONTEND_URL in tutormfe/patches/openedx-lms-development-settings
- fix typo in README.rst
- remove unused courseware.courseware_mfe flag for edx-platform master
  branch