### PR TITLE
feat: enable course home MFE Progress tab by default

### DIFF
--- a/tutormfe/templates/mfe/hooks/lms/init
+++ b/tutormfe/templates/mfe/hooks/lms/init
@@ -11,3 +11,9 @@ site-configuration set ENABLE_PROFILE_MICROFRONTEND true
 site-configuration unset ENABLE_PROFILE_MICROFRONTEND
 ./manage.py lms waffle_delete --flags learner_profile.redirect_to_microfrontend
 {% endif %}
+
+{% if MFE_LEARNING_MFE_APP %}
+(./manage.py lms waffle_flag --list | grep course_home.course_home_mfe_progress_tab) || ./manage.py lms waffle_flag --create --everyone course_home.course_home_mfe_progress_tab
+{% else %}
+./manage.py lms waffle_delete --flags course_home.course_home_mfe_progress_tab
+{% endif %}


### PR DESCRIPTION
Enabling course home MFE progress tab by default according to https://github.com/openedx/build-test-release-wg/issues/81#issuecomment-936228147

<img width="1321" alt="image" src="https://user-images.githubusercontent.com/877401/136471078-3dd26916-bc6e-4bb5-a075-9682fc3f31e5.png">
