### PR TITLE
fix: typo when calling default_site_port environment variable

### DIFF
--- a/tutormfe/patches/caddyfile
+++ b/tutormfe/patches/caddyfile
@@ -1,4 +1,4 @@
-{{ MFE_HOST }}{$default_site-port} {
+{{ MFE_HOST }}{$default_site_port} {
     respond / 204
     request_body {
         max_size 2MB


### PR DESCRIPTION
This PR aims to fix a typo in an environment variable referenced in the caddyfile patch. IT should be `default_site_port` according to [this definition](https://github.com/overhangio/tutor/blob/72baae0e27379821652ee7db495708f9cb6396ff/tutor/templates/local/docker-compose.prod.yml#L11).

@regisb 