### PR TITLE
fix: missing remote-image hook

### DIFF
--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -46,6 +46,9 @@ hooks = {
     "build-image": {
         "mfe": "{{ MFE_DOCKER_IMAGE }}",
     },
+    "remote-image": {
+        "mfe": "{{ MFE_DOCKER_IMAGE }}",
+    },
     "init": ["lms"],
 }
 


### PR DESCRIPTION
## Description

The command `tutor images push mfe` was not working since `remote-image`
hook was not present in the mfe plugin. This PR adds the missing hook.

## Supporting information

https://discuss.overhang.io/t/cant-push-custom-mfe-image-to-container-registry/2257

## Testing instructions

1. Without this PR, try to run `tutor images push mfe`, It will show the error - `Error: Image 'mfe' could not be found`.
1. Pull this PR and run `tutor images push mfe`, it will attempt to push the `mfe` image.

