### PR TITLE
avoid using two different Caddy base images

### DIFF
--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -13,6 +13,7 @@ config = {
         "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}overhangio/openedx-mfe:{{ MFE_VERSION }}",
         "HOST": "apps.{{ LMS_HOST }}",
         "COMMON_VERSION": "{{ OPENEDX_COMMON_VERSION }}",
+        "MFE_CADDY_DOCKER_IMAGE": "{{ DOCKER_IMAGE_CADDY }}"
         "ACCOUNT_MFE_APP": {
             "name": "account",
             "repository": "https://github.com/edx/frontend-app-account",

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -56,7 +56,7 @@ RUN bash -c "set -a && source /openedx/env/production && source /openedx/env/pro
 {% endfor %}
 
 ####### final production image with all static assets
-FROM docker.io/caddy:2.4.3-alpine as production
+FROM {{ MFE_CADDY_DOCKER_IMAGE }} as production
 
 RUN mkdir -p /openedx/dist
 


### PR DESCRIPTION
Currently openedx itself and mfe are using two different Caddy base images, which is not ideal. This PR fixes this.