### PR TITLE
fix: studio url in dev mode

### DIFF
--- a/tutormfe/templates/mfe/build/mfe/env/development
+++ b/tutormfe/templates/mfe/build/mfe/env/development
@@ -7,5 +7,6 @@ LOGOUT_URL='http://{{ LMS_HOST }}:8000/logout'
 MARKETING_SITE_BASE_URL='http://{{ LMS_HOST }}:8000'
 NODE_ENV=development
 REFRESH_ACCESS_TOKEN_ENDPOINT='http://{{ LMS_HOST }}:8000/login_refresh'
+STUDIO_BASE_URL='http://{{ CMS_HOST }}:8001'
 
 {{ patch("mfe-env-development") }}


### PR DESCRIPTION
This fixes the link to the studio that is displayed in the learning mfe in
every section.