### PR TITLE
fix: Escape single quotes inside the platform name.

### DIFF
--- a/tutormfe/templates/mfe/build/mfe/env/production
+++ b/tutormfe/templates/mfe/build/mfe/env/production
@@ -19,7 +19,7 @@ NODE_ENV=production
 PUBLISHER_BASE_URL=''
 REFRESH_ACCESS_TOKEN_ENDPOINT='{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}/login_refresh'
 SEGMENT_KEY=''
-SITE_NAME='{{ PLATFORM_NAME }}'
+SITE_NAME='{{ PLATFORM_NAME|replace("'", "\'") }}'
 STUDIO_BASE_URL='{{ "https" if ENABLE_HTTPS else "http" }}://{{ CMS_HOST }}'
 USER_INFO_COOKIE_NAME='user-info'
 


### PR DESCRIPTION
Because this file is sourced as bash, if there are single quotes inside
the platform for apostrophes(eg "Feanil's Dev Setup") then the config
file becomes malformed.

Fix it by escaping any apostrophes in the platform name.