### PR TITLE
fix: in production env, use double quotes for platform name

### DIFF
--- a/tutormfe/templates/mfe/build/mfe/env/production
+++ b/tutormfe/templates/mfe/build/mfe/env/production
@@ -19,7 +19,7 @@ NODE_ENV=production
 PUBLISHER_BASE_URL=''
 REFRESH_ACCESS_TOKEN_ENDPOINT='{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}/login_refresh'
 SEGMENT_KEY=''
-SITE_NAME='{{ PLATFORM_NAME|replace("'", "\'") }}'
+SITE_NAME="{{ PLATFORM_NAME|replace('"', '\\"') }}"
 STUDIO_BASE_URL='{{ "https" if ENABLE_HTTPS else "http" }}://{{ CMS_HOST }}'
 USER_INFO_COOKIE_NAME='user-info'
 


### PR DESCRIPTION
## Description

Single quotes cannot be easily escaped in bash.
In particular, this doesn't work:

    SITE_NAME='Kyle\'s "very cool" Open edX'

because the backslash is treated literally.
The easiest workaround is to surround the string in double
quotes and then escape the double quotes, e.g.:

    SITE_NAME="Kyle's \"very cool\" Open edX"

This fix should allow `tutor images build mfe` to work
correctly when PLATFORM_NAME contains single or double quotes.

Note: This, along with any other fix at the tutor-mfe level,
is partial at best IMO. I know of no reliable way to pass
arbitrary unicode strings through bash variables without
hitting some quoting or encoding issue. The real fix would
involve getting rid of the bash environment files at the
frontend-build level and using something with more robust
string handling like YAML.

## Testing

```
$ tutor config save --set PLATFORM_NAME="Kyle's \"very cool\" Open edX instance"
Configuration saved to /home/kyle/.local/share/tutor-nightly/config.yml
Environment generated in /home/kyle/.local/share/tutor-nightly/env

$ tutor config printvalue PLATFORM_NAME
Kyle's "very cool" Open edX instance

$ cat $(tutor config printroot)/env/plugins/mfe/build/mfe/env/production | grep SITE_NAME
SITE_NAME="Kyle's \"very cool\" Open edX instance"

$ (source $(tutor config printroot)/env/plugins/mfe/build/mfe/env/production && echo $SITE_NAME)
Kyle's "very cool" Open edX instance
```