### PR TITLE
fix: further escape single quotes inside the platform name

### DIFF
--- a/tutormfe/templates/mfe/build/mfe/env/production
+++ b/tutormfe/templates/mfe/build/mfe/env/production
@@ -19,7 +19,7 @@ NODE_ENV=production
 PUBLISHER_BASE_URL=''
 REFRESH_ACCESS_TOKEN_ENDPOINT='{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}/login_refresh'
 SEGMENT_KEY=''
-SITE_NAME='{{ PLATFORM_NAME|replace("'", "\'") }}'
+SITE_NAME='{{ PLATFORM_NAME|replace("'", "'\\''") }}'
 STUDIO_BASE_URL='{{ "https" if ENABLE_HTTPS else "http" }}://{{ CMS_HOST }}'
 USER_INFO_COOKIE_NAME='user-info'
 


### PR DESCRIPTION
## Description

In bash, single quotes within single quotes cannot be escaped
directly. In particular, this doesn't work:

    SITE_NAME='Kyle\'s "very cool" Open edX'

because the backslash is treated literally.

A workaround is actually to close the single-quoted string,
follow it with an escaped single quote, and then re-open a
new single quoted string. The following three lines
yield an identical, correctly-escaped SITE_NAME:

    SITE_NAME='Kyle' + "\'" + 's "very cool" Open edX'
    SITE_NAME='Kyle' + \' + 's "very cool" Open edX'
    SITE_NAME='Kyle'\''s "very cool" Open edX'

This commit changes the envs/production template
to use such an escaping strategy.

This fix should allow `tutor images build mfe` to work
correctly when PLATFORM_NAME contains single quotes,
double quotes, or pieces of bash substitution syntax
like '$' (which would get messed up if we just used double
quotes).

Note: This, along with any other fix at the tutor-mfe level,
is partial at best IMO. I know of no reliable way to pass
arbitrary unicode strings through bash variables without
hitting some quoting or encoding issue. The real fix would
involve getting rid of the bash environment files at the
frontend-build level and using something with more robust
string handling like YAML.

## Testing

```
$ tutor config save --set PLATFORM_NAME="Kyle's \"very cool\" Open edX in\$tance"
Configuration saved to /home/kyle/.local/share/tutor-nightly/config.yml
Environment generated in /home/kyle/.local/share/tutor-nightly/env

$ tutor config printvalue PLATFORM_NAME
Kyle's "very cool" Open edX in$tance

$ cat $(tutor config printroot)/env/plugins/mfe/build/mfe/env/production | grep SITE_NAME
SITE_NAME='Kyle'\''s "very cool" Open edX in$tance'

$ (source $(tutor config printroot)/env/plugins/mfe/build/mfe/env/production && echo $SITE_NAME)
Kyle's "very cool" Open edX in$tance
```