### PR TITLE
Add "nightly" suffix to the tutor dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.5",
-    install_requires=["tutor>=13.0.0,<14.0.0"],
+    install_requires=["tutor>=13.0.0-nightly,<14.0.0-nightly"],
     entry_points={"tutor.plugin.v0": ["mfe = tutormfe.plugin"]},
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
I was following [Installing Tutor Nightly](https://docs.tutor.overhang.io/tutorials/nightly.html?highlight=master#installing-tutor-nightly) documentation page, and realized that `tutor config printvalue OPENEDX_COMMON_VERSION` yields `maple.2` instead of `master`.

It appeared that `pip install -e ./tutor-mfe` step uninstalls nightly version of `tutor` and installs it from PyPi:
```
Installing collected packages: tutor, tutor-mfe
  Attempting uninstall: tutor
    Found existing installation: tutor 13.1.8-nightly
    Uninstalling tutor-13.1.8-nightly:
      Successfully uninstalled tutor-13.1.8-nightly
  Running setup.py develop for tutor-mfe
Successfully installed tutor-13.1.8 tutor-mfe
```

This PR is adding `nighly` suffix to the tutor version. As a result, the package won't uninstall `nighly` version, but alone still will install the correct version from PyPi.