### PR TITLE
feat: deprecate `runserver` in favor of `start`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -192,19 +192,37 @@ MFE development
 
 Tutor makes it possible to run any MFE in development mode. For instance, to run the "profile" MFE::
 
-    tutor dev runserver profile
+    tutor dev start profile
 
 Then, access http://apps.local.overhang.io:1995/profile/u/YOURUSERNAME
 
-To run your own fork of an MFE, start by copying the MFE repo on the host::
+You can also bind-mount your own fork of an MFE. For example::
 
-    tutor dev bindmount profile /openedx/app
+    cd /path/to/frontend-app-profile
+    npm install  # Ensure NPM requirements are installed into your fork.
+    tutor dev start --mount=. profile
 
-Then, run a development server that bind-mounts the repo::
+The changes you make to your fork will be automatically picked up and hot-reloaded by your development server.
 
-    tutor dev runserver --volume=/openedx/app profile
+This works for custom MFEs, as well. For example, if you added your own MFE named frontend-app-myapp, then you can bind-mount it like so::
 
-The changes you make to ``$(tutor config printroot)/volumes/app/`` will be automatically picked up and hot-reloaded by your development server.
+    cd /path/to/frontend-app-myapp
+    npm install
+    tutor dev start --mount=. myapp
+
+However, if you try to bind-mount an unknown MFE, you will see a Docker Compose error such as::
+
+  ERROR: The Compose file is invalid because:
+  Service myapp has neither an image nor a build context specified. At least one must be provided.
+
+Please note that bind-mounting a fork is only available for development (``tutor dev ...``), since production MFEs are compiled and served out of a single container. If you want to use a fork of an MFE in production, then you will need to set the repository URL in ``$(tutor config printroot)/config.yml``::
+
+    MFE_PROFILE_MFE_APP
+        name: profile
+        repository: "https://github.com/YOUR_FORK_ORGANIZATION/frontend-app-profile"
+        port: 1995
+
+and then rebuild the MFE container image with ``tutor images build mfe``.
 
 Uninstall
 ---------

--- a/tutormfe/patches/local-docker-compose-dev-services
+++ b/tutormfe/patches/local-docker-compose-dev-services
@@ -7,6 +7,8 @@
         target: {{ app["name"] }}-dev
     ports:
         - "127.0.0.1:{{ app["port"] }}:{{ app["port"] }}"
+    stdin_open: true
+    tty: true
     volumes:
         - ../plugins/mfe/apps/mfe/webpack.dev.config.js:/openedx/app/webpack.dev.config.js:ro
     env_file:

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -63,6 +63,25 @@ tutor_hooks.Filters.IMAGES_BUILD.add_item(
 )
 
 
+@tutor_hooks.Filters.COMPOSE_MOUNTS.add()
+def _mount_frontend_apps(volumes, name):
+    """
+    If the user mounts any repo named frontend-app-APPNAME, then make sure
+    it's available in the APPNAME service container. This is only applicable
+    in dev mode, because in production, all MFEs are built and hosted on the
+    singular 'mfe' service container.
+    """
+    prefix = "frontend-app-"
+    if name.startswith(prefix):
+        # Assumption:
+        # For each repo named frontend-app-APPNAME, there is an associated
+        # docker-compose service named APPNAME. If this assumption is broken,
+        # then Tutor will try to mount the repo in a service that doesn't exist.
+        app_name = name.split(prefix)[1]
+        volumes += [(app_name, "/openedx/app")]
+    return volumes
+
+
 @tutor_hooks.Filters.IMAGES_PULL.add()
 @tutor_hooks.Filters.IMAGES_PUSH.add()
 def _add_remote_mfe_image_iff_customized(images, user_config):


### PR DESCRIPTION
See individual commit messages.

Blocks https://github.com/overhangio/tutor/pull/644