### PR TITLE
fix: Add env variable to enable records button in profile

### DIFF
--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -38,6 +38,11 @@ config = {
             "name": "profile",
             "repository": "https://github.com/edx/frontend-app-profile",
             "port": 1995,
+             "env": {
+                "production": {
+                    "ENABLE_LEARNER_RECORD_MFE": "true",
+                },
+            },
         },
     },
 }


### PR DESCRIPTION
  Learning-MFE won't view records button, unless the
  ENABLE_LEARNER_RECORD_MFE is set to true.
  This shall fixes: openedx/build-test-release-wg/issues/168