### PR TITLE
perf: re-order Dockerfile stages to significantly optimize build speed

### DIFF
--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -53,6 +53,11 @@ COPY --from={{ app["name"] }}-i18n /openedx/app/src/i18n/messages /openedx/app/s
 ENV PUBLIC_PATH='/{{ app["name"] }}/'
 EXPOSE {{ app['port'] }}
 CMD ["npm", "run", "start"]
+
+{% endfor %}
+
+{% for app in iter_values_named(suffix="MFE_APP") %}
+
 ######## {{ app["name"] }} (production)
 FROM {{ app["name"] }}-dev AS {{ app["name"] }}
 COPY ./env/production /openedx/env/production

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -24,19 +24,21 @@ RUN echo "copying i18n data" \
   echo "done."
 
 {% for app in iter_values_named(suffix="MFE_APP") %}
+
 ######## {{ app["name"] }} (src)
 FROM base AS {{ app["name"] }}-src
 RUN git clone {{ app["repository"] }} --branch {{ app.get("version", MFE_COMMON_VERSION) }} --depth 1 .
 RUN stat /openedx/app/src/i18n/messages 2> /dev/null || (echo "missing messages folder" && mkdir -p /openedx/app/src/i18n/messages)
+
 ######## {{ app["name"] }} (i18n)
 FROM base AS {{ app["name"] }}-i18n
 COPY --from={{ app["name"] }}-src /openedx/app/src/i18n/messages /openedx/app/src/i18n/messages
 COPY --from=i18n /openedx/i18n/{{ app["name"] }} /openedx/i18n/{{ app["name"] }}
 COPY --from=i18n /openedx/i18n/i18n-merge.js /openedx/i18n/i18n-merge.js
 RUN /openedx/i18n/i18n-merge.js /openedx/app/src/i18n/messages /openedx/i18n/{{ app["name"] }} /openedx/app/src/i18n/messages
+
 ######## {{ app["name"] }} (dev)
 FROM base AS {{ app["name"] }}-dev
-
 COPY --from={{ app["name"] }}-src /openedx/app/package.json /openedx/app/package.json
 COPY --from={{ app["name"] }}-src /openedx/app/package-lock.json /openedx/app/package-lock.json
 ARG NPM_REGISTRY=https://registry.npmjs.org/
@@ -67,6 +69,7 @@ RUN touch /openedx/env/production.override \
   {%- endfor %}
   && echo "done setting production overrides"
 RUN bash -c "set -a && source /openedx/env/production && source /openedx/env/production.override && npm run build"
+
 {% endfor %}
 
 ####### final production image with all static assets


### PR DESCRIPTION
## Description

Previously, build stages were ordered like this in the
rendered Dockerfile (dependencies in parenthases):

* base
* i18n        (base)
* app1-src    (base)
* app1-i18n   (base, app1-src)
* app1-dev    (base, app1-src, app1-i18n)
* app1        (app1-dev)
* app2-src    (base, app2-src)
* app2-i18n   (base, app2-src)
* app2-dev    (base, app2-src, app2-i18n)
* app2        (app2-dev)
* ...
* production  (app1, app2, ..., appN)

MFEs in dev mode only use the output of the *-dev stages.
However, because some of the *-dev stages came after
the intermediate production stages in the Dockerfile (app1, app2, etc),
Docker unnecessarily built the prod stages whenever `tutor dev start`
was run, which often forced users to wait through the prod-only
`npm run build`.

This commit reorders the build stages to look like this:

* base
* i18n        (base)
* app1-src    (base)
* app1-i18n   (base, app1-src)
* app1-dev    (base, app1-src, app1-i18n)
* app2-src    (base, app2-src)
* app2-i18n   (base, app2-src)
* app2-dev    (base, app2-src, app2-i18n)
* ...
* app1        (app1-dev)
* app2        (app2-dev)
* ...
* production  (app1, app2, ..., appN)

Now that the *-dev stages are all before the production stages,
the MFE dev build should be significantly quicker.

## Review

@arbrandes Can you take a look?