### PR TITLE
fix: escape space in platform name

### DIFF
--- a/tutormfe/templates/mfe/build/mfe/env/production
+++ b/tutormfe/templates/mfe/build/mfe/env/production
@@ -19,7 +19,7 @@ NODE_ENV=production
 PUBLISHER_BASE_URL=
 REFRESH_ACCESS_TOKEN_ENDPOINT={% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}/login_refresh
 SEGMENT_KEY=
-SITE_NAME={{ PLATFORM_NAME|replace("'", "'\\''") }}
+SITE_NAME={{ PLATFORM_NAME|replace("'", "'\\''")|replace(" ","\ ") }}
 STUDIO_BASE_URL={{ "https" if ENABLE_HTTPS else "http" }}://{{ CMS_HOST }}
 USER_INFO_COOKIE_NAME=user-info
 


### PR DESCRIPTION
  tutor-mfe set SITE_NAME env variable of mfe to equal
  PLATFORM_NAME config value, however in case it has a space, this
  would result SITE_NAME to be empty.
  This change prefix space with \ as, i.e My Site becaomse
  My\ Site.
  Before this might not has been issued because all values were
  wrapped with ' hence #56

  To test this change (you have to be in production mode)
  - Set your PLATFORM_NAME to any thing that incldues space
  - Build the mfe image
  - Check `document.title` in dev console of any mfe
  - It will not incldue PLATFORM_NAME

  After applying this patch, the last step above, should result
  the PLATFORM_NAME i.e. "Learning | PLATFORM_NAME"