### PR TITLE
feat: add learner record MFE to plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,7 @@ In addition, this plugin comes with a few MFEs which are enabled by default:
 - `Gradebook <https://github.com/edx/frontend-app-gradebook/>`__
 - `Learning <https://github.com/edx/frontend-app-learning/>`__
 - `Profile <https://github.com/edx/frontend-app-profile/>`__
+- `Learner Records <https://github.com/edx/frontend-app-learner-record/>`__
 
 Instructions for using each of these MFEs are given below.
 

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -44,6 +44,17 @@ config = {
                 },
             },
         },
+        "RECORDS_MFE_APP": {
+            "name": "records",
+            "repository": "https://github.com/openedx/frontend-app-learner-record",
+            "port": 1990,
+            "env": {
+                "production": {
+                    "SUPPORT_URL_LEARNER_RECORDS":"",
+                    "USE_LR_MFE": "",
+                },
+            },
+        },
     },
 }
 


### PR DESCRIPTION
Adds the learner record MFE to `tutor-mfe` to use in place of the old UI in credentials, as we are planning on deprecating soon.

![image](https://user-images.githubusercontent.com/16495365/195165933-edb999e9-5461-4c38-9c2d-b11e1c6efa85.png)
