### PR TITLE
feat: enable gzip compression

### DIFF
--- a/tutormfe/patches/caddyfile
+++ b/tutormfe/patches/caddyfile
@@ -3,5 +3,6 @@
     request_body {
         max_size 2MB
     }
+    encode gzip
     import proxy "mfe:8002"
 }


### PR DESCRIPTION
 Compressing assests would lead to readuce transfer size.
 As testing with frontend-app-learning/Olive, the network traffic
 before was about ~4MB, after this it became ~1MB.

 This change was suggested by Google Lighthouse[1], there are of
 course more suggestion but this was one the easiest and one of most
 impactful.

 [1]: https://web.dev/uses-text-compression
 
 ## Lighthouse score before: 
 
<img width="717" alt="image" src="https://user-images.githubusercontent.com/16361375/195293832-fac8528f-cb3e-49bd-aa3f-003aeee6a8be.png">

### Suggestion Before 

<img width="733" alt="image" src="https://user-images.githubusercontent.com/16361375/195294372-b9f42550-4798-4ad5-9d5e-5542db64a3f2.png">

 ## Lighthouse score after: 
 
<img width="717" alt="image" src="https://user-images.githubusercontent.com/16361375/195293951-525e12f3-8f14-4e6f-a94d-71825046a608.png">

### Suggestions After

<img width="733" alt="image" src="https://user-images.githubusercontent.com/16361375/195294505-2151f784-4666-4afe-8b28-d8c83df594b9.png">

 