### PR TITLE
fix: Remove hardcoded loopback ip in dev docker-compose

### DIFF
--- a/tutormfe/patches/local-docker-compose-dev-services
+++ b/tutormfe/patches/local-docker-compose-dev-services
@@ -6,7 +6,7 @@
         context: ../plugins/mfe/build/mfe/
         target: {{ app["name"] }}-dev
     ports:
-        - "127.0.0.1:{{ app["port"] }}:{{ app["port"] }}"
+        - "{{ app["port"] }}:{{ app["port"] }}"
     stdin_open: true
     tty: true
     volumes:


### PR DESCRIPTION
In the docker compose for development, the loopback IP address is hardcoded to 127.0.0.1. In some dev environments, e.g. in cloud environments like Cloud9, or in Windows WSL, the internal web server is accessed via a different IP address. Removing the 127.0.0.1 in the ports section will fix this problem.
Fixes #72 