### PR TITLE
fix(dev): inherit local webpack.dev.config.js

### DIFF
--- a/tutormfe/patches/local-docker-compose-dev-services
+++ b/tutormfe/patches/local-docker-compose-dev-services
@@ -10,7 +10,7 @@
     stdin_open: true
     tty: true
     volumes:
-        - ../plugins/mfe/apps/mfe/webpack.dev.config.js:/openedx/app/webpack.dev.config.js:ro
+        - ../plugins/mfe/apps/mfe/webpack.dev-tutor.config.js:/openedx/app/webpack.dev-tutor.config.js:ro
     env_file:
         - ../plugins/mfe/build/mfe/env/production
         - ../plugins/mfe/build/mfe/env/development

--- a/tutormfe/templates/mfe/apps/mfe/webpack.dev-tutor.config.js
+++ b/tutormfe/templates/mfe/apps/mfe/webpack.dev-tutor.config.js
@@ -1,6 +1,11 @@
 const { merge } = require('webpack-merge');
+const fs = require('fs');
 
-const baseDevConfig = require('@edx/frontend-build/config/webpack.dev.config.js');
+const baseDevConfig = (
+  fs.existsSync('./webpack.dev.config.js')
+    ? require('./webpack.dev.config.js')
+    : require('@edx/frontend-build/config/webpack.dev.config.js')
+);
 
 module.exports = merge(baseDevConfig, {
   // This configuration needs to be defined here, because CLI

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -54,7 +54,7 @@ COPY --from={{ app["name"] }}-src /openedx/app /openedx/app
 COPY --from={{ app["name"] }}-i18n /openedx/app/src/i18n/messages /openedx/app/src/i18n/messages
 ENV PUBLIC_PATH='/{{ app["name"] }}/'
 EXPOSE {{ app['port'] }}
-CMD ["npm", "run", "start"]
+CMD ["npm", "run", "start", "---", "--config", "./webpack.dev-tutor.config.js"]
 
 {% endfor %}
 


### PR DESCRIPTION
 A small fix for issue #71 to avoid overwriting the local `webpack.dev.config.js` in MFEs with the plugin's version of the file mounted at container start
 
The MFEs targetted by this all have a local `webpack.dev.config.js`. Here are the ones branched for the olive release:

    frontend-app-gradebook
    frontend-app-publisher
    frontend-app-ora-grading
    frontend-app-communications
    frontend-app-program-console
    frontend-app-learner-dashboard
    frontend-app-library-authoring

To account for the 2 possible cases for all MFEs, the fix was tested and confirmed to work with:
-  `frontend-app-gradebook` (using local config)
-  `frontend-app-learning` (using config resolved from `frontend-platform`)

The modification in `Dockerfile` won't trigger a long image rebuild as it affects only the last step (`CMD`).

My choice at the moment was to rename the plugin's `webpack.dev.config.js` to `webpack.dev-tutor.config.js`.
Please tell me if another file name or location is preferable (e.g. `tutor/webpack.dev.config.js`)
.