### PR TITLE
Fix (build): use NPM_REGISTRY from the config

### DIFF
--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -41,7 +41,7 @@ RUN /openedx/i18n/i18n-merge.js /openedx/app/src/i18n/messages /openedx/i18n/{{ 
 FROM base AS {{ app["name"] }}-dev
 COPY --from={{ app["name"] }}-src /openedx/app/package.json /openedx/app/package.json
 COPY --from={{ app["name"] }}-src /openedx/app/package-lock.json /openedx/app/package-lock.json
-ARG NPM_REGISTRY=https://registry.npmjs.org/
+ARG NPM_REGISTRY={{ NPM_REGISTRY }}
 {{ patch("mfe-dockerfile-pre-npm-install") }}
 {# Required for building optipng on M1 #}
 ENV CPPFLAGS=-DPNG_ARM_NEON_OPT=0


### PR DESCRIPTION
**TL;DR -** Use the `NPM_REGISTRY` config in Dockerfile, the same way it's done in other Tutor Dockerfiles (tutor-discovery, tutor-ecommerce, tutor:openedx, tutor-contrib-credentials).

We just replace the default registry URL with the config `NPM_REGISTRY` which defaults to the same value.

This is required in order to use a custom registry either for caching or for accessing private packages.

**Testing**
I've been using that fix for a while. I'm currently surviving long repetitive downloads thanks to my local pull-through cache NPM registry powered by [Verdaccio](https://verdaccio.org/docs/what-is-verdaccio/).

FYI @arbrandes @regisb