### PR TITLE
fix: duplicate git package removed

### DIFF
--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/node:16.14-bullseye-slim AS base
 RUN apt update \
   && apt install -y git \
     # required for cwebp-bin
-    gcc git libgl1 libxi6 make \
+    gcc libgl1 libxi6 make \
     # additionally required for gifsicle, mozjpeg, and optipng (on arm)
     autoconf libtool pkg-config zlib1g-dev \
     # additionally required for node-sass (on arm)


### PR DESCRIPTION
Hi
I was reading MFE `Dockerfile` and noticed that the git package was mentioned twice in `apt install` level, so I removed the second one :)
I know it doesn't make any harm but, this way is cleaner, I guess.