### PR TITLE
Delete user account issue on Account MFE

### DIFF
--- a/tutormfe/templates/mfe/tasks/lms/init
+++ b/tutormfe/templates/mfe/tasks/lms/init
@@ -1,5 +1,6 @@
 {% if MFE_ACCOUNT_MFE_APP %}
 (./manage.py lms waffle_flag --list | grep account.redirect_to_microfrontend) || ./manage.py lms waffle_flag --create --everyone account.redirect_to_microfrontend
+./manage.py lms populate_retirement_states
 {% else %}
 ./manage.py lms waffle_delete --flags account.redirect_to_microfrontend
 {% endif %}


### PR DESCRIPTION
Hi everyone
I noticed that deleting the user account doesn't work by default.
<img src="https://user-images.githubusercontent.com/49523567/201884951-0204033d-a6fe-4784-9a68-50a3b19d2cb2.png" width="150px"/>

after a [little search](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/user_retire/service_setup.html#retirement-states), I found that we need to populate retirement states before deleting a user.
I've tested this and it worked after retirement states were populated.
 
<img src="https://user-images.githubusercontent.com/49523567/201887213-71f2a029-afe5-41f3-9f1b-42921584aed4.png" width="150px"/>


this PR will add `populate_retirement_states` command if the Account MFE was selected.