### PR TITLE
fix: add missing CSRF configuration

### DIFF
--- a/tutormfe/patches/openedx-lms-development-settings
+++ b/tutormfe/patches/openedx-lms-development-settings
@@ -27,6 +27,7 @@ CSRF_TRUSTED_ORIGINS.append("{{ MFE_HOST }}:{{ app["port"] }}")
 # https://openedx.github.io/frontend-platform/module-Config.html
 MFE_CONFIG = {
     "BASE_URL": "{{ MFE_HOST }}",
+    "CSRF_TOKEN_API_PATH": "/csrf/api/v1/token",
     {%- if MFE_PROFILE_MFE_APP %}
     "ACCOUNT_PROFILE_URL": "http://{{ MFE_HOST }}:{{ MFE_PROFILE_MFE_APP["port"] }}",
     {%- endif %}

--- a/tutormfe/patches/openedx-lms-production-settings
+++ b/tutormfe/patches/openedx-lms-production-settings
@@ -24,6 +24,7 @@ ALLOWED_HOSTS.append("{{ MFE_HOST }}")
 # Start of Dynamic config API settings
 MFE_CONFIG = {
     "BASE_URL": "{{ MFE_HOST }}",
+    "CSRF_TOKEN_API_PATH": "/csrf/api/v1/token",
     {%- if MFE_PROFILE_MFE_APP %}
     "ACCOUNT_PROFILE_URL": "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/{{ MFE_PROFILE_MFE_APP["name"] }}",
     {%- endif %}


### PR DESCRIPTION
When introducing dynamic config[1], `CSRF_TOKEN_API_PATH` was removed from the MFE build environment and not added to the corresponding Django settings, leading to POST failures across the board.

This addresses the problem by adding `CSRF_TOKEN_API_PATH` back in.

[1] https://github.com/overhangio/tutor-mfe/pull/69