### PR TITLE
fix: Don't rebuild image on `local start`

### DIFF
--- a/tutormfe/patches/local-docker-compose-prod-services
+++ b/tutormfe/patches/local-docker-compose-prod-services
@@ -1,8 +1,6 @@
 # MFE
 mfe:
     image: {{ MFE_DOCKER_IMAGE }}
-    build:
-        context: ../plugins/mfe/build/mfe/
     restart: unless-stopped
     depends_on:
         - lms


### PR DESCRIPTION
Since we no longer need the build context to pass in MFE configuration at runtime, by removing it from the `tutor local` docker-compose we can avoid rebuilding the image whenever a `start` is issued.