### PR TITLE
feat: do not build mfe image on `local start`

### DIFF
--- a/tutormfe/patches/local-docker-compose-prod-services
+++ b/tutormfe/patches/local-docker-compose-prod-services
@@ -1,8 +1,6 @@
 # MFE
 mfe:
     image: {{ MFE_DOCKER_IMAGE }}
-    build:
-        context: ../plugins/mfe/build/mfe/
     restart: unless-stopped
     depends_on:
         - lms


### PR DESCRIPTION
Now that the mfe image is pushed to docker.io, there is no longer any need to re-build every time we run `tutor local start`.