### PR TITLE
fix: visual - missing code tags in Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Other Tutor plugin developers can take advantage of this plugin to deploy their 
         }
     }
 
-The MFE assets will then be bundled in the "mfe" Docker image whenever it is rebuilt with `tutor images build mfe`. Assets will be served at ``http(s)://{{ MFE_HOST }}/{{ MYMFE_MFE_APP["name"] }}``. Developers are free to add extra template patches to their plugins, as usual: for instance LMS setting patches to make sure that the LMS correctly connects to the MFEs.
+The MFE assets will then be bundled in the "mfe" Docker image whenever it is rebuilt with ``tutor images build mfe``. Assets will be served at ``http(s)://{{ MFE_HOST }}/{{ MYMFE_MFE_APP["name"] }}``. Developers are free to add extra template patches to their plugins, as usual: for instance LMS setting patches to make sure that the LMS correctly connects to the MFEs.
 
 Disabling individual MFEs
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Added some missing code tags to readme which makes it a bit harder to read (markdown vs rst syntax)