### PR TITLE
fix: Add account url in dynamic config

### DIFF
--- a/tutormfe/patches/openedx-lms-development-settings
+++ b/tutormfe/patches/openedx-lms-development-settings
@@ -29,6 +29,7 @@ AUTHN_MICROFRONTEND_DOMAIN  = "{{ MFE_HOST }}/authn"
 MFE_CONFIG["DISABLE_ENTERPRISE_LOGIN"] = True
 {% elif app_name == "account" %}
 ACCOUNT_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ app["port"] }}/account"
+MFE_CONFIG["ACCOUNT_SETTINGS_URL"] = ACCOUNT_MICROFRONTEND_URL
 {% elif app_name == "course-authoring" %}
 MFE_CONFIG["ENABLE_NEW_EDITOR_PAGES"] = True
 MFE_CONFIG["ENABLE_PROGRESS_GRAPH_SETTINGS"] = True

--- a/tutormfe/patches/openedx-lms-production-settings
+++ b/tutormfe/patches/openedx-lms-production-settings
@@ -30,6 +30,7 @@ AUTHN_MICROFRONTEND_DOMAIN  = "{{ MFE_HOST }}/authn"
 MFE_CONFIG["DISABLE_ENTERPRISE_LOGIN"] = True
 {% elif app_name == "account" %}
 ACCOUNT_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/account"
+MFE_CONFIG["ACCOUNT_SETTINGS_URL"] = ACCOUNT_MICROFRONTEND_URL
 {% elif app_name == "course-authoring" %}
 MFE_CONFIG["ENABLE_NEW_EDITOR_PAGES"] = True
 MFE_CONFIG["ENABLE_PROGRESS_GRAPH_SETTINGS"] = True


### PR DESCRIPTION
   frontend-component-header since version v.3.5 requires the
   the settings of ACCOUNT_SETTINGS_URL to exists as it uses
   it point to the account MFE.
   - openedx/frontend-component-header/pull/210 PR that add the setting the componenet
   - openedx/wg-build-test-release/issues/268 which this fixes