### PR TITLE
fix: pngquant error during build on linux/arm64

### DIFF
--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -4,10 +4,12 @@ RUN apt update \
   && apt install -y git \
     # required for cwebp-bin
     gcc libgl1 libxi6 make \
-    # additionally required for gifsicle, mozjpeg, and optipng (on arm)
+    # required for gifsicle, mozjpeg, and optipng (on arm)
     autoconf libtool pkg-config zlib1g-dev \
-    # additionally required for node-sass (on arm)
-    python g++
+    # required for node-sass (on arm)
+    python g++ \
+    # required for image-webpack-loader (on arm)
+    libpng-dev
 
 RUN mkdir -p /openedx/app /openedx/env
 WORKDIR /openedx/app


### PR DESCRIPTION
Building the mfe Docker image on arm64 triggers the following error in the 'account-prod' stage:

    Cannot find module 'imagemin-pngquant'

This was due to a missing system package.

I find it strange that no one reported this issue before, when there are plenty of users running macOS with arm64. I discovered this issue while setting up a multi-arch build CI environment.