### PR TITLE
fix: "account" menu item from MFE menus

### DIFF
--- a/changelog.d/20230526_152532_regis.md
+++ b/changelog.d/20230526_152532_regis.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix un-clickable "account" menu item. (by @ghassanmas and @regisb)

--- a/tutormfe/patches/openedx-lms-development-settings
+++ b/tutormfe/patches/openedx-lms-development-settings
@@ -32,6 +32,9 @@ CSRF_TRUSTED_ORIGINS.append("{{ MFE_HOST }}:{{ app["port"] }}")
 MFE_CONFIG = {
     "BASE_URL": "{{ MFE_HOST }}",
     "CSRF_TOKEN_API_PATH": "/csrf/api/v1/token",
+{%- if MFE_ACCOUNT_MFE_APP %}
+    "ACCOUNT_SETTINGS_URL": ACCOUNT_MICROFRONTEND_URL,
+{%- endif %}
 {%- if MFE_PROFILE_MFE_APP %}
     "ACCOUNT_PROFILE_URL": "http://{{ MFE_HOST }}:{{ MFE_PROFILE_MFE_APP["port"] }}",
 {%- endif %}

--- a/tutormfe/patches/openedx-lms-production-settings
+++ b/tutormfe/patches/openedx-lms-production-settings
@@ -29,6 +29,9 @@ CSRF_TRUSTED_ORIGINS.append("{{ MFE_HOST }}")
 MFE_CONFIG = {
     "BASE_URL": "{{ MFE_HOST }}",
     "CSRF_TOKEN_API_PATH": "/csrf/api/v1/token",
+{%- if MFE_ACCOUNT_MFE_APP %}
+    "ACCOUNT_SETTINGS_URL": ACCOUNT_MICROFRONTEND_URL,
+{%- endif %}
 {%- if MFE_PROFILE_MFE_APP %}
     "ACCOUNT_PROFILE_URL": "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/{{ MFE_PROFILE_MFE_APP["name"] }}",
 {%- endif %}


### PR DESCRIPTION
The "account" menu item could not be clicked in other MFEs, such as the profile.

This is a backport of another fix to Palm:
https://github.com/overhangio/tutor-mfe/pull/121

Close #128.