### PR TITLE
feat: invalidate build cache on upstream changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,10 +129,16 @@ Other MFE developers can take advantage of this plugin to deploy their own MFEs.
             "repository": "https://github.com/myorg/mymfe",
             "port": 2001,
             "version": "me/my-custom-branch", # optional, will default to the Open edX current tag.
+            "refs": https://api.github.com/repos/myorg/mymfe/git/refs/heads", # optional
         }
         return mfes
 
-The MFE assets will then be bundled in the "mfe" Docker image whenever it is rebuilt with ``tutor images build mfe``. Assets will be served at ``http(s)://{{ MFE_HOST }}/mymfe``. Developers are free to add extra template patches to their plugins, as usual: for instance LMS setting patches to make sure that the LMS correctly connects to the MFEs.
+The MFE assets will then be bundled in the "mfe" Docker image whenever it is rebuilt with ``tutor images build mfe``. Providing a ``refs`` URL will ensure the build cache for that MFE is invalidated whenever a change is detected upstream at the git version in question.  You can use the `GitHub references API`_ or the `GitLab branches API`_ for this.
+
+.. _GitHub references API: https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#get-a-reference
+.. _GitLab branches API: https://docs.gitlab.com/ee/api/branches.html#get-single-repository-branch
+
+Assets will be served at ``http(s)://{{ MFE_HOST }}/mymfe``. Developers are free to add extra template patches to their plugins, as usual: for instance LMS setting patches to make sure that the LMS correctly connects to the MFEs.
 
 Disabling individual MFEs
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/changelog.d/20230627_090554_arbrandes_cache_invalidation.md
+++ b/changelog.d/20230627_090554_arbrandes_cache_invalidation.md
@@ -1,0 +1,1 @@
+- [Improvement] Invalidate build cache for individual MFEs if there were upstream changes. (by @arbrandes)

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -26,38 +26,47 @@ config = {
 CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
     "authn": {
         "repository": "https://github.com/openedx/frontend-app-authn",
+        "refs": "https://api.github.com/repos/openedx/frontend-app-authn/git/refs/tags",
         "port": 1999,
     },
     "account": {
         "repository": "https://github.com/openedx/frontend-app-account",
+        "refs": "https://api.github.com/repos/openedx/frontend-app-account/git/refs/tags",
         "port": 1997,
     },
     "communications": {
         "repository": "https://github.com/openedx/frontend-app-communications",
+        "refs": "https://api.github.com/repos/openedx/frontend-app-communications/git/refs/tags",
         "port": 1984,
     },
     "course-authoring": {
         "repository": "https://github.com/openedx/frontend-app-course-authoring",
+        "refs": "https://api.github.com/repos/openedx/frontend-app-course-authoring/git/refs/tags",
         "port": 2001,
     },
     "discussions": {
         "repository": "https://github.com/openedx/frontend-app-discussions",
+        "refs": "https://api.github.com/repos/openedx/frontend-app-discussions/git/refs/tags",
         "port": 2002,
     },
     "gradebook": {
         "repository": "https://github.com/openedx/frontend-app-gradebook",
+        "refs": "https://api.github.com/repos/openedx/frontend-app-gradebook/git/refs/tags",
         "port": 1994,
     },
     "learning": {
         "repository": "https://github.com/openedx/frontend-app-learning",
+        "refs": "https://api.github.com/repos/openedx/frontend-app-learning/git/refs/tags",
         "port": 2000,
     },
     "ora-grading": {
         "repository": "https://github.com/openedx/frontend-app-ora-grading",
+        "refs": "https://api.github.com/repos/openedx/frontend-app-ora-grading/git/refs/tags",
         "port": 1993,
     },
     "profile": {
         "repository": "https://github.com/openedx/frontend-app-profile",
+        "refs": "https://api.github.com/repos/openedx/frontend-app-profile/git/refs/tags",
         "port": 1995,
     },
 }

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -33,6 +33,10 @@ RUN echo "copying i18n data" \
 ####################### {{ app_name }} MFE
 ######## {{ app_name }} (git)
 FROM base AS {{ app_name }}-git
+{#- Invalidate the build cache if a change is detected upstream #}
+{%- if app.get("refs") %}
+ADD {{ app["refs"] }}/{{ app.get("version", MFE_COMMON_VERSION) }} /tmp/gitref-{{ app_name }}
+{%- endif %}
 RUN git clone {{ app["repository"] }} --branch {{ app.get("version", MFE_COMMON_VERSION) }} --depth 1 .
 
 ######## {{ app_name }} (src)


### PR DESCRIPTION
This will invalidate the image build cache for each MFE whenever:
    
1. A direct URL to the repository's branch refs is provided
    
and
    
2. The head of the branch being built changed between builds.
    
For Github, this is available via [1].  For Gitlab, via [2].
    
[1] https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#get-a-reference
[2] https://docs.gitlab.com/ee/api/branches.html#get-single-repository-branch