### PR TITLE
feat: allow patching the Dockerfile per MFE

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -233,6 +233,25 @@ The same applies to installing a custom `brand <https://github.com/openedx/brand
         )
     )
 
+In both cases above, the ``npm`` commands affect every MFE being built.  If you want have different commands apply to different MFEs, you can add one or more patches to ``mfe-dockerfile-post-npm-install-*`` instead.  For instance, you could install one particular version of the header to the Learning MFE by patching ``mfe-dockerfile-post-npm-install-learning``, and another one to the ORA Grading MFE by patching ``mfe-dockerfile-post-npm-install-ora-grading``::
+
+    hooks.Filters.ENV_PATCHES.add_items(
+        [
+            (
+                "mfe-dockerfile-post-npm-install-learning",
+                """
+        RUN npm install '@edx/frontend-component-header@git+https://github.com/your-repo/frontend-component-header.git#your-branch'
+        """
+            ),
+            (
+                "mfe-dockerfile-post-npm-install-ora-grading",
+                """
+        RUN npm install '@edx/frontend-component-header@git+https://github.com/your-repo/frontend-component-header.git#your-other-branch'
+        """
+            ),
+        ]
+    )
+
 
 Installing from a private npm registry
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/changelog.d/20230623_101803_arbrandes_dockerfile_patches_per_mfe.md
+++ b/changelog.d/20230623_101803_arbrandes_dockerfile_patches_per_mfe.md
@@ -1,0 +1,1 @@
+- [Improvement] Allow patching the Dockerfile per MFE. (by @arbrandes)

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -54,12 +54,14 @@ COPY --from={{ app_name }}-src /package.json /openedx/app/package.json
 COPY --from={{ app_name }}-src /package-lock.json /openedx/app/package-lock.json
 ARG NPM_REGISTRY={{ NPM_REGISTRY }}
 {{ patch("mfe-dockerfile-pre-npm-install") }}
+{{ patch("mfe-dockerfile-pre-npm-install-{}".format(app_name)) }}
 {#- Required for building optipng on M1 #}
 ENV CPPFLAGS=-DPNG_ARM_NEON_OPT=0
 {#- We define this environment variable to bypass an issue with the installation of pact https://github.com/pact-foundation/pact-js-core/issues/264 #}
 ENV PACT_SKIP_BINARY_INSTALL=true
 RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/root/.npm,sharing=shared {% endif %}npm clean-install --no-audit --no-fund --registry=$NPM_REGISTRY
 {{ patch("mfe-dockerfile-post-npm-install") }}
+{{ patch("mfe-dockerfile-post-npm-install-{}".format(app_name)) }}
 COPY --from={{ app_name }}-src / /openedx/app
 COPY --from={{ app_name }}-i18n /openedx/app/src/i18n/messages /openedx/app/src/i18n/messages
 EXPOSE {{ app['port'] }}


### PR DESCRIPTION
This should allow managing individual MFE node_modules (such as installing custom dependencies for l10n purposes) without having to fork the corresponding upstream codebases.