### PR TITLE
fix: pick default GH refs API endpoint based on package version

### DIFF
--- a/changelog.d/20230628_084907_arbrandes_cache_invalidation_take_2.md
+++ b/changelog.d/20230628_084907_arbrandes_cache_invalidation_take_2.md
@@ -1,0 +1,1 @@
+- [Improvement] Select GitHub refs API endpoint based on version suffix. (by @arbrandes)

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -9,7 +9,7 @@ import pkg_resources
 from tutor import hooks as tutor_hooks
 from tutor.hooks import priorities
 
-from .__about__ import __version__
+from .__about__ import __version__, __version_suffix__
 from .hooks import MFE_ATTRS_TYPE, MFE_APPS
 
 config = {
@@ -23,50 +23,55 @@ config = {
 }
 
 
+# If the package version suffix is set (for instance, in the nightly branch) use the "heads" Github refs API endpoint by default.
+def gh_refs_path() -> str:
+    return "heads" if __version_suffix__ else "tags"
+
+
 CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
     "authn": {
         "repository": "https://github.com/openedx/frontend-app-authn",
-        "refs": "https://api.github.com/repos/openedx/frontend-app-authn/git/refs/tags",
+        "refs": "https://api.github.com/repos/openedx/frontend-app-authn/git/refs/" + gh_refs_path(),
         "port": 1999,
     },
     "account": {
         "repository": "https://github.com/openedx/frontend-app-account",
-        "refs": "https://api.github.com/repos/openedx/frontend-app-account/git/refs/tags",
+        "refs": "https://api.github.com/repos/openedx/frontend-app-account/git/refs/" + gh_refs_path(),
         "port": 1997,
     },
     "communications": {
         "repository": "https://github.com/openedx/frontend-app-communications",
-        "refs": "https://api.github.com/repos/openedx/frontend-app-communications/git/refs/tags",
+        "refs": "https://api.github.com/repos/openedx/frontend-app-communications/git/refs/" + gh_refs_path(),
         "port": 1984,
     },
     "course-authoring": {
         "repository": "https://github.com/openedx/frontend-app-course-authoring",
-        "refs": "https://api.github.com/repos/openedx/frontend-app-course-authoring/git/refs/tags",
+        "refs": "https://api.github.com/repos/openedx/frontend-app-course-authoring/git/refs/" + gh_refs_path(),
         "port": 2001,
     },
     "discussions": {
         "repository": "https://github.com/openedx/frontend-app-discussions",
-        "refs": "https://api.github.com/repos/openedx/frontend-app-discussions/git/refs/tags",
+        "refs": "https://api.github.com/repos/openedx/frontend-app-discussions/git/refs/" + gh_refs_path(),
         "port": 2002,
     },
     "gradebook": {
         "repository": "https://github.com/openedx/frontend-app-gradebook",
-        "refs": "https://api.github.com/repos/openedx/frontend-app-gradebook/git/refs/tags",
+        "refs": "https://api.github.com/repos/openedx/frontend-app-gradebook/git/refs/" + gh_refs_path(),
         "port": 1994,
     },
     "learning": {
         "repository": "https://github.com/openedx/frontend-app-learning",
-        "refs": "https://api.github.com/repos/openedx/frontend-app-learning/git/refs/tags",
+        "refs": "https://api.github.com/repos/openedx/frontend-app-learning/git/refs/" + gh_refs_path(),
         "port": 2000,
     },
     "ora-grading": {
         "repository": "https://github.com/openedx/frontend-app-ora-grading",
-        "refs": "https://api.github.com/repos/openedx/frontend-app-ora-grading/git/refs/tags",
+        "refs": "https://api.github.com/repos/openedx/frontend-app-ora-grading/git/refs/" + gh_refs_path(),
         "port": 1993,
     },
     "profile": {
         "repository": "https://github.com/openedx/frontend-app-profile",
-        "refs": "https://api.github.com/repos/openedx/frontend-app-profile/git/refs/tags",
+        "refs": "https://api.github.com/repos/openedx/frontend-app-profile/git/refs/" + gh_refs_path(),
         "port": 1995,
     },
 }


### PR DESCRIPTION
Picking up where https://github.com/overhangio/tutor-mfe/pull/131 left off.