### PR TITLE
feat: don't override imagepullpolicy on k8s

### DIFF
--- a/changelog.d/20230627_162842_regis.md
+++ b/changelog.d/20230627_162842_regis.md
@@ -1,0 +1,1 @@
+- [Improvement] Don't override `imagePullPolicy` in Kubernetes. This was only necessary in older releases. (by @regisb)

--- a/tutormfe/patches/k8s-deployments
+++ b/tutormfe/patches/k8s-deployments
@@ -17,7 +17,6 @@ spec:
       containers:
         - name: mfe
           image: {{ MFE_DOCKER_IMAGE }}
-          imagePullPolicy: Always
           ports:
             - containerPort: 8002
           volumeMounts:


### PR DESCRIPTION
We should use the default cluster value for imagePullPolicy. This makes
it easier to run the MFE with Minikube:
https://minikube.sigs.k8s.io/docs/handbook/pushing/

> Tip 1: Remember to turn off the imagePullPolicy:Always (use
> imagePullPolicy:IfNotPresent or imagePullPolicy:Never) in your yaml
> file. Otherwise Kubernetes won’t use your locally build image and it
> will pull from the network.