### PR TITLE
fix: link to profile in dev

### DIFF
--- a/changelog.d/20230802_123027_regis_fix_dev_profile_link.md
+++ b/changelog.d/20230802_123027_regis_fix_dev_profile_link.md
@@ -1,0 +1,1 @@
+- [Bugfix] In development, fix link to profile in header. (by @regisb)

--- a/tutormfe/patches/openedx-lms-development-settings
+++ b/tutormfe/patches/openedx-lms-development-settings
@@ -44,8 +44,8 @@ MFE_CONFIG["LEARNING_BASE_URL"] = "http://{{ MFE_HOST }}:{{ app["port"] }}"
 {% elif app_name == "ora-grading" %}
 ORA_GRADING_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ app["port"] }}/ora-grading"
 {% elif app_name == "profile" %}
-PROFILE_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}:{{ app["port"] }}/profile/u/"
-MFE_CONFIG["ACCOUNT_PROFILE_URL"] = "http://{{ MFE_HOST }}:{{ app["port"] }}"
+PROFILE_MICROFRONTEND_URL = "http:/{{ MFE_HOST }}:{{ app["port"] }}/profile/u/"
+MFE_CONFIG["ACCOUNT_PROFILE_URL"] = "http://{{ MFE_HOST }}:{{ app["port"] }}/profile"
 {% elif app_name == "communications" %}
 COMMUNICATIONS_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ app["port"] }}/communications"
 MFE_CONFIG["SCHEDULE_EMAIL_SECTION"] = True


### PR DESCRIPTION
In development, the link to the profile page was incorrect in the header bar of the learning MFE (and other MFEs) as well. Note that the link was correct in the dashboard.