### PR TITLE
chore: corrected typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ ORA Grading
 .. image:: https://raw.githubusercontent.com/overhangio/tutor-mfe/master/screenshots/ora-grading.png
     :alt: ORA Grading MFE screenshot
 
-When enabled, Open Response Assesments ("ORA") that have a staff grading step will link to this new MFE, either when clicking "Grade Available Responses" from the exercise itself, or via a link in the Instructor Dashboard.  It is meant to streamline the grading process with better previews of submitted content.
+When enabled, Open Response Assessments ("ORA") that have a staff grading step will link to this new MFE, either when clicking "Grade Available Responses" from the exercise itself, or via a link in the Instructor Dashboard.  It is meant to streamline the grading process with better previews of submitted content.
 
 Profile
 ~~~~~~~~~

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -235,7 +235,7 @@ for path in glob(
     )
 ):
     with open(path, encoding="utf-8") as patch_file:
-        # Here we force tutor-mfe lms patches to be loaded first, thus ensuring when opreators override
+        # Here we force tutor-mfe lms patches to be loaded first, thus ensuring when operators override
         # MFE_CONFIG and/or MFE_CONFIG_OVERRIDES, their patches will be loaded after this plugin's
         patch_name = os.path.basename(path)
         priority = (


### PR DESCRIPTION
This will fix the following typos:
```
Assesments -> Assessments
opreators -> operators
```