### PR TITLE
docs: square characters replaced with →

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ Gradebook
 .. image:: https://raw.githubusercontent.com/overhangio/tutor-mfe/master/screenshots/gradebook.png
     :alt: Gradebook MFE screenshot
 
-This instructor-only MFE is for viewing individual and aggregated grade results for a course. To access this MFE, go to a course 🡒 🡒 Instructor tab 🡒 Student Admin 🡒 View gradebook. The URL should be: ``http(s)://{{ MFE_HOST }}/gradebook/{{ course ID }}``. When running locally, the gradebook of the demo course is available at: http://apps.local.overhang.io/gradebook/course-v1:edX+DemoX+Demo_Course
+This instructor-only MFE is for viewing individual and aggregated grade results for a course. To access this MFE, go to a course → Instructor tab → Student Admin → View gradebook. The URL should be: ``http(s)://{{ MFE_HOST }}/gradebook/{{ course ID }}``. When running locally, the gradebook of the demo course is available at: http://apps.local.overhang.io/gradebook/course-v1:edX+DemoX+Demo_Course
 
 Learning
 ~~~~~~~~


### PR DESCRIPTION
This will fix the same issue we had in [tutor-xqueue](https://github.com/overhangio/tutor-xqueue/pull/19)

![Screenshot from 2023-08-20 11-33-04](https://github.com/overhangio/tutor-mfe/assets/49523567/40f18b7c-94d8-4025-916f-d44f57f0d941)
