### PR TITLE
feat: additional patches before npm build in the Dockerfile

### DIFF
--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -90,6 +90,8 @@ CMD ["/bin/bash", "-c", "npm run start --- --config ./webpack.dev-tutor.config.j
 ######## {{ app_name }} (production)
 FROM {{ app_name }}-common AS {{ app_name }}-prod
 ENV NODE_ENV=production
+{{ patch("mfe-dockerfile-pre-npm-build") }}
+{{ patch("mfe-dockerfile-pre-npm-build-{}".format(app_name)) }}
 RUN npm run build
 {% endfor %}
 


### PR DESCRIPTION
## Description

Add additional patches just before the build step similar to the `mfe-dockerfile-pre-npm-install` patches. This will allow running additional instructions before building the assets (e.g. adding new `ENV ...` lines to enable new relic).

I'm not sure if a 'post build' patch would be useful.