### PR TITLE
feat: add atlas pull for the communications app FC-0012

### DIFF
--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -17,7 +17,7 @@ RUN apt update \
 
 RUN mkdir -p /openedx/app /openedx/env
 WORKDIR /openedx/app
-ENV PATH ./node_modules/.bin:${PATH}
+ENV PATH /openedx/app/node_modules/.bin:${PATH}
 
 ######## i18n strings
 FROM base AS i18n
@@ -68,6 +68,13 @@ RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/root/.npm,sharing=s
 {{ patch("mfe-dockerfile-post-npm-install-{}".format(app_name)) }}
 COPY --from={{ app_name }}-src / /openedx/app
 COPY --from={{ app_name }}-i18n /openedx/app/src/i18n/messages /openedx/app/src/i18n/messages
+
+# Whenever a new MFE supports Atlas, it should be added to this list.
+# When all MFEs support Atlas, this if-statement should be removed.
+{% if app_name in ["communications"] %}
+RUN make OPENEDX_ATLAS_PULL=true pull_translations
+{% endif %}
+
 EXPOSE {{ app['port'] }}
 
 # Configuration needed at build time


### PR DESCRIPTION
Adds `atlas pull` to the Communications MFE. Support for other MFEs will come.

## Previously open issues

Here's a couple issues that needs to be tackled:

 - Issue: How to enable the `atlas_pull` conditionally? 
   * Old solution: `CORE_MFE_APPS` feature.
   * Updated solution: Hard-coded `if app_name == communications`
 - Issue: How to install `openedx-atlas` and `platform-frontend` which are required for `atlas pull`?
   * Solution: In the package.json of the communications MFE.
 - Issue: Should we use `make pull translations`? or hand-craft an `atlas pull` command?
   * For discovery Regis recommended to avoid using make and writing an atlas command instead.
   * For MFEs, it's better to use the Makefile step to allow each frontend to control its own plugins.
 - Issue: After changing directory to `cd src/i18n/messages` the `node_modules/.bin` is no longer available.
   * Suggested solution: Use `ENV PATH /openedx/app/node_modules/.bin:${PATH}` in `base` instead of the relative PATH.
 - Issue: `atlas pull` is only available for master because https://github.com/openedx/frontend-app-communications/pull/124 is a post-Palm pull request. 
   * Patch has been done done on `palm.master`: https://github.com/openedx/frontend-app-communications/pull/156

## TODO before merge
 - [x] Test the translations and post a screenshot
    <details><summary>Screenshot: Je parle français! </summary>
    <img src="https://github.com/overhangio/tutor-mfe/assets/645156/4743605e-f68c-4e0b-8335-7c9594146817" />
    </details> 
 - [x] Backport the `atlas pull` to the Palm: https://github.com/openedx/frontend-app-communications/pull/156
- [x] Wait for Quince support and merge into Quince: https://github.com/overhangio/tutor-mfe/pull/156
 - [x] Verify that `atlas pull` and `intl-import.js` are both working as expected:
<details><summary>Debug atlas pull and the generated src/i18n/index.js</summary>

```
RUN ls -R /openedx/app/src/i18n/; cat /openedx/app/src/i18n/index.js; exit 1         0.4s
------                                                                                                                        
 > [communications-i18n 4/8] RUN ls -R /openedx/app/src/i18n/; cat /openedx/app/src/i18n/index.js; exit 1:                    
#0 0.385 /openedx/app/src/i18n/:                                                                                              
#0 0.385 index.js                                                                                                             
#0 0.385 messages                                                                                                             
#0 0.385                                                                                                                      
#0 0.385 /openedx/app/src/i18n/messages:
#0 0.385 frontend-app-communications
#0 0.385 frontend-component-footer
#0 0.385 frontend-component-header
#0 0.385 paragon
#0 0.385 
#0 0.385 /openedx/app/src/i18n/messages/frontend-app-communications:
#0 0.385 fr_CA.json
#0 0.385 index.js
#0 0.385 
#0 0.385 /openedx/app/src/i18n/messages/frontend-component-footer:
#0 0.385 ar.json
#0 0.385 de.json
#0 0.385 fr_CA.json
#0 0.385 index.js
#0 0.385 
#0 0.385 /openedx/app/src/i18n/messages/frontend-component-header:
#0 0.385 ar.json
#0 0.385 de.json
#0 0.385 fr_CA.json
#0 0.385 index.js
#0 0.385 
#0 0.385 /openedx/app/src/i18n/messages/paragon:
#0 0.385 ar.json
#0 0.385 de.json
#0 0.385 fr_CA.json
#0 0.385 index.js
#0 0.385 // This file is generated by the openedx/frontend-platform's "intl-import.js" script.
#0 0.385 //
#0 0.385 // Refer to the i18n documents in https://docs.openedx.org/en/latest/developers/references/i18n.html to update
#0 0.385 // the file and use the Micro-frontend i18n pattern in new repositories.
#0 0.385 //
#0 0.385 
#0 0.385 import messagesFromFrontendComponentHeader from './messages/frontend-component-header';
#0 0.385 import messagesFromFrontendComponentFooter from './messages/frontend-component-footer';
#0 0.385 import messagesFromParagon from './messages/paragon';
#0 0.385 import messagesFromFrontendAppCommunications from './messages/frontend-app-communications';
#0 0.385 
#0 0.385 export default [
#0 0.385   messagesFromFrontendComponentHeader,
#0 0.385   messagesFromFrontendComponentFooter,
#0 0.385   messagesFromParagon,
#0 0.385   messagesFromFrontendAppCommunications,
#0 0.385 ];
------
```

</details> 


## Nightly vs Master

All `atlas` integration is going to target `nightly` branches so it's included in Quince but not Palm.

The exception is for the Communications MFE because it has not translations and needs `atlas` in Palm, therefore it's being used on `master`.

References
----------
This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
