### PR TITLE
Fix: MFE_HOST check with the new CONFIG_LOADED action

### DIFF
--- a/changelog.d/20231002_172323_codewithemad_config_loaded_action.md
+++ b/changelog.d/20231002_172323_codewithemad_config_loaded_action.md
@@ -1,0 +1,1 @@
+[Feature] The new CONFIG_LOADED action checks if MFE_HOST is a subdomain of LMS_HOST. If not, display a warning message to the user. (by @CodeWithEmad)

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor>=16.0.0,<17.0.0"],
+    install_requires=["tutor>=16.1.2,<17.0.0"],
     entry_points={"tutor.plugin.v1": ["mfe = tutormfe.plugin"]},
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -6,9 +6,10 @@ import typing as t
 
 import pkg_resources
 
+from tutor import fmt
 from tutor import hooks as tutor_hooks
 from tutor.hooks import priorities
-
+from tutor.types import Config, get_typed
 from .__about__ import __version__, __version_suffix__
 from .hooks import MFE_ATTRS_TYPE, MFE_APPS
 
@@ -258,3 +259,20 @@ tutor_hooks.Filters.CONFIG_UNIQUE.add_items(
 tutor_hooks.Filters.CONFIG_OVERRIDES.add_items(
     list(config.get("overrides", {}).items())
 )
+
+
+# Actions
+@tutor_hooks.Actions.CONFIG_LOADED.add()
+def _check_mfe_host(config: Config) -> None:
+    """
+    This will check if the MFE_HOST is a subdomain of LMS_HOST.
+    if not, prints a warning to notify the user.
+    """
+
+    lms_host = get_typed(config, "LMS_HOST", str, "")
+    mfe_host = get_typed(config, "MFE_HOST", str, "")
+    if not mfe_host.endswith("." + lms_host):
+        fmt.echo_alert(
+            f'Warning: MFE_HOST="{mfe_host}" is not a subdomain of LMS_HOST="{lms_host}". '
+            "This configuration is not typically recommended and may lead to unexpected behavior."
+        )


### PR DESCRIPTION
As a part of https://github.com/overhangio/tutor/issues/557, we should warn the users if they're not following the apps.LMS_HOST pattern for the MFE_HOST.
This will introduce a new check to see if the MFE_HOST is a subdomain of LMS_HOST or not using the new [CONFIG_LOADED action](https://github.com/overhangio/tutor/pull/901) .