### PR TITLE
fix: remove trailing slash from PUBLIC_PATH env var

### DIFF
--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -72,7 +72,7 @@ EXPOSE {{ app['port'] }}
 
 # Configuration needed at build time
 ENV APP_ID={{ app_name }}
-ENV PUBLIC_PATH='/{{ app_name }}/'
+ENV PUBLIC_PATH='/{{ app_name }}'
 # We could in theory point the mfe_config API directly to the LMS. But for that we would
 # have to code the LMS url into the mfe image, and this configuration is user-dependent.
 # So we point to a relative url that will be a proxy for the LMS.


### PR DESCRIPTION
We previously generated the PUBLIC_PATH base for each MFE with a trailing slash, e.g. "/authn/". But the actual links that point to these from the LMS and Studio don't have a trailing slash in them, e.g. "/authn". This commit removes the trailing slash to be consistent.