### PR TITLE
fix: remove trailing slash from PUBLIC_PATH env var

### DIFF
--- a/changelog.d/20231003_133500_dave_remove_trailing_slash.md
+++ b/changelog.d/20231003_133500_dave_remove_trailing_slash.md
@@ -1,0 +1,11 @@
+
+<!--
+Create a changelog entry for every new user-facing change. Please respect the following instructions:
+- Indicate breaking changes by prepending an explosion 💥 character.
+- Prefix your changes with either [Bugfix], [Improvement], [Feature], [Security], [Deprecation].
+- You may optionally append "(by @<author>)" at the end of the line, where "<author>" is either one (just one)
+of your GitHub username, real name or affiliated organization. These affiliations will be displayed in
+the release notes for every release.
+-->
+
+- [Bugfix] Remove the trailing slash from auto-generated PUBLIC_PATH env vars for MFEs in order to be consistent with LMS/Studio config, and so that we don't have to strip it off on the JavaScript side after the React Router 6 upgrade. (by @ormsbee)

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -72,7 +72,7 @@ EXPOSE {{ app['port'] }}
 
 # Configuration needed at build time
 ENV APP_ID={{ app_name }}
-ENV PUBLIC_PATH='/{{ app_name }}/'
+ENV PUBLIC_PATH='/{{ app_name }}'
 # We could in theory point the mfe_config API directly to the LMS. But for that we would
 # have to code the LMS url into the mfe image, and this configuration is user-dependent.
 # So we point to a relative url that will be a proxy for the LMS.


### PR DESCRIPTION
We previously generated the PUBLIC_PATH base for each MFE with a trailing slash, e.g. "/authn/". But the actual links that point to these from the LMS and Studio don't have a trailing slash in them, e.g. "/authn". This commit removes the trailing slash to be consistent.