### PR TITLE
chore: update CSRF_TRUSTED_ORIGINS for Django 4.2

### DIFF
--- a/tutormfe/patches/openedx-cms-development-settings
+++ b/tutormfe/patches/openedx-cms-development-settings
@@ -4,6 +4,6 @@
 COURSE_AUTHORING_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ app["port"] }}/course-authoring"
 CORS_ORIGIN_WHITELIST.append("http://{{ MFE_HOST }}:{{ app["port"] }}")
 LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}:{{ app["port"] }}")
-CSRF_TRUSTED_ORIGINS.append("{{ MFE_HOST }}:{{ app["port"] }}")
+CSRF_TRUSTED_ORIGINS.append("http://{{ MFE_HOST }}:{{ app["port"] }}")
 {% endif %}
 {% endfor %}

--- a/tutormfe/patches/openedx-cms-production-settings
+++ b/tutormfe/patches/openedx-cms-production-settings
@@ -7,4 +7,4 @@ COURSE_AUTHORING_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}htt
 
 LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}")
 CORS_ORIGIN_WHITELIST.append("{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}")
-CSRF_TRUSTED_ORIGINS.append("{{ MFE_HOST }}")
+CSRF_TRUSTED_ORIGINS.append("{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}")

--- a/tutormfe/patches/openedx-lms-development-settings
+++ b/tutormfe/patches/openedx-lms-development-settings
@@ -59,7 +59,7 @@ MFE_CONFIG["SCHEDULE_EMAIL_SECTION"] = True
 # {{ app_name }} MFE
 CORS_ORIGIN_WHITELIST.append("http://{{ MFE_HOST }}:{{ app["port"] }}")
 LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}:{{ app["port"] }}")
-CSRF_TRUSTED_ORIGINS.append("{{ MFE_HOST }}:{{ app["port"] }}")
+CSRF_TRUSTED_ORIGINS.append("http://{{ MFE_HOST }}:{{ app["port"] }}")
 {% endfor %}
 
 {{ patch("mfe-lms-common-settings") }}

--- a/tutormfe/patches/openedx-lms-production-settings
+++ b/tutormfe/patches/openedx-lms-production-settings
@@ -56,7 +56,7 @@ MFE_CONFIG["SCHEDULE_EMAIL_SECTION"] = True
 
 LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}")
 CORS_ORIGIN_WHITELIST.append("{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}")
-CSRF_TRUSTED_ORIGINS.append("{{ MFE_HOST }}")
+CSRF_TRUSTED_ORIGINS.append("{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}")
 
 {{ patch("mfe-lms-common-settings") }}
 {{ patch("mfe-lms-production-settings") }}


### PR DESCRIPTION
We are going to upgrade to Django 4.2 for Quince.
Issue: https://github.com/openedx/wg-build-test-release/issues/315
PR to edx-platform: https://github.com/openedx/edx-platform/pull/33516 (will be merged only after Tutor preparation for Django4.2)

[Notes](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3726802953/Pending+Release+Quince#Operational-%E2%9A%99%EF%B8%8F) about Django4.2 schema changes for CSRF_TRUSTED_ORIGINS.


This PR has been testing for Django 3.2 as well.