### PR TITLE
refactor: use MFE refs caching for master branches

### DIFF
--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -28,65 +28,41 @@ config = {
     },
 }
 
-
-def get_github_refs_path(name: str) -> str:
-    """
-    Generate a URL to access refs in heads (nightly) or tags (stable) via Github API.
-    Args:
-        name (str): Consisted of the repository owner and the repository name, as a string in 'owner/repo' format.
-
-    Returns:
-        str: A string URL to the Github API, pointing to heads if version_suffix is set, tags otherwise.
-
-    """
-
-    return f"https://api.github.com/repos/{name}/git/refs/{'heads' if __version_suffix__ else 'tags'}"
-
-
 CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
     "authn": {
         "repository": "https://github.com/openedx/frontend-app-authn",
-        "refs": get_github_refs_path("openedx/frontend-app-authn"),
         "port": 1999,
     },
     "account": {
         "repository": "https://github.com/openedx/frontend-app-account",
-        "refs": get_github_refs_path("openedx/frontend-app-account"),
         "port": 1997,
     },
     "communications": {
         "repository": "https://github.com/openedx/frontend-app-communications",
-        "refs": get_github_refs_path("openedx/frontend-app-communications"),
         "port": 1984,
     },
     "course-authoring": {
         "repository": "https://github.com/openedx/frontend-app-course-authoring",
-        "refs": get_github_refs_path("openedx/frontend-app-course-authoring"),
         "port": 2001,
     },
     "discussions": {
         "repository": "https://github.com/openedx/frontend-app-discussions",
-        "refs": get_github_refs_path("openedx/frontend-app-discussions"),
         "port": 2002,
     },
     "gradebook": {
         "repository": "https://github.com/openedx/frontend-app-gradebook",
-        "refs": get_github_refs_path("openedx/frontend-app-gradebook"),
         "port": 1994,
     },
     "learning": {
         "repository": "https://github.com/openedx/frontend-app-learning",
-        "refs": get_github_refs_path("openedx/frontend-app-learning"),
         "port": 2000,
     },
     "ora-grading": {
         "repository": "https://github.com/openedx/frontend-app-ora-grading",
-        "refs": get_github_refs_path("openedx/frontend-app-ora-grading"),
         "port": 1993,
     },
     "profile": {
         "repository": "https://github.com/openedx/frontend-app-profile",
-        "refs": get_github_refs_path("openedx/frontend-app-profile"),
         "port": 1995,
     },
 }

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -34,10 +34,7 @@ RUN echo "copying i18n data" \
 ######## {{ app_name }} (git)
 FROM base AS {{ app_name }}-git
 {#- Invalidate the build cache if a change is detected upstream #}
-{%- if app.get("refs") %}
-ADD {{ app["refs"] }}/{{ app.get("version", MFE_COMMON_VERSION) }} /tmp/gitref-{{ app_name }}
-{%- endif %}
-RUN git clone {{ app["repository"] }} --branch {{ app.get("version", MFE_COMMON_VERSION) }} --depth 1 .
+ADD --keep-git-dir=true {{ app["repository"] }}#{{ app.get("version", MFE_COMMON_VERSION) }} .
 
 ######## {{ app_name }} (src)
 # Empty layer with just the repo at the root, for build-time bind-mounts


### PR DESCRIPTION
This PR fixes https://github.com/overhangio/tutor-mfe/issues/161 by using the `--keep-git-dir` flag of the add command. The docker build step is cached if the branch is intact since the last build. However, if the branch is updated, the cache is invalidated and a new build is required -- as expected.

<img width="1173" alt="Screenshot 2023-12-04 at 13 38 50" src="https://github.com/overhangio/tutor-mfe/assets/19173947/0914e6ef-a737-4842-aaee-a332b7865ca8">

The image above shows that the first build had ditch the previous cache; the second build shows that the image is rebuilt with no changes on the branch, therefore it is cached.

cc: @regisb @arbrandes 