### PR TITLE
fix: auto-build 3rd-party MFEs

### DIFF
--- a/changelog.d/20231205_164707_regis_fix_3rd_party_build.md
+++ b/changelog.d/20231205_164707_regis_fix_3rd_party_build.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix image build/pull/push when 3rd-party microfrontends are bind-mounted. (by @regisb)

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -143,19 +143,21 @@ tutor_hooks.Filters.IMAGES_PUSH.add_item(
 
 
 # Build, pull and push {mfe}-dev images
-for mfe_name, mfe_attrs in iter_mfes():
-    name = f"{mfe_name}-dev"
-    tag = "{{ DOCKER_REGISTRY }}overhangio/openedx-" + name + ":{{ MFE_VERSION }}"
-    tutor_hooks.Filters.IMAGES_BUILD.add_item(
-        (
-            name,
-            os.path.join("plugins", "mfe", "build", "mfe"),
-            tag,
-            (f"--target={mfe_name}-dev",),
+@tutor_hooks.Actions.PLUGINS_LOADED.add()
+def _mounted_mfe_image_management() -> None:
+    for mfe_name, _mfe_attrs in iter_mfes():
+        name = f"{mfe_name}-dev"
+        tag = "{{ DOCKER_REGISTRY }}overhangio/openedx-" + name + ":{{ MFE_VERSION }}"
+        tutor_hooks.Filters.IMAGES_BUILD.add_item(
+            (
+                name,
+                os.path.join("plugins", "mfe", "build", "mfe"),
+                tag,
+                (f"--target={mfe_name}-dev",),
+            )
         )
-    )
-    tutor_hooks.Filters.IMAGES_PULL.add_item((name, tag))
-    tutor_hooks.Filters.IMAGES_PUSH.add_item((name, tag))
+        tutor_hooks.Filters.IMAGES_PULL.add_item((name, tag))
+        tutor_hooks.Filters.IMAGES_PUSH.add_item((name, tag))
 
 
 # init script


### PR DESCRIPTION
When a 3rd party develops an MFE and bind-mounts it, it is expected that the dev image will be automatically built on `dev launch`. Also, author should be able to build it with `tutor images build mymfe-dev`. This was not the case for plugins that were loaded after the "mfe" plugin. For instance: "partners" is loaded after "mfe".

See discussion:
https://discuss.openedx.org/t/issues-developing-a-non-core-mfe-using-tutor/11855