### PR TITLE
feat: allow post npm build patch in Dockerfile

### DIFF
--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -93,6 +93,8 @@ CMD ["/bin/bash", "-c", "npm run start --- --config ./webpack.dev-tutor.config.j
 FROM {{ app_name }}-common AS {{ app_name }}-prod
 ENV NODE_ENV=production
 RUN npm run build
+{{ patch("mfe-dockerfile-post-npm-build") }}
+{{ patch("mfe-dockerfile-post-npm-build-{}".format(app_name)) }}
 {% endfor %}
 
 ####### final production image with all static assets


### PR DESCRIPTION
As per the [issue](https://github.com/overhangio/tutor-mfe/issues/167), adding a patch to allow changes in Dockerfile after the npm build has completed. The patch can be used with the name:

- `mfe-dockerfile-post-npm-build` to apply the patch to every mfe
- `mfe-dockerfile-post-npm-build-<mfe>` where mfe indicates the name of the specific mfe to apply the patch to

This change was not documented int the README as MFE patches are to be documented separately in lieu of [this issue](https://github.com/overhangio/tutor-mfe/issues/168).