### PR TITLE
feat: `get_mfe` template function

### DIFF
--- a/changelog.d/20231206_170625_regis_get_mfe.md
+++ b/changelog.d/20231206_170625_regis_get_mfe.md
@@ -1,0 +1,1 @@
+- [Feature] Introduce a `get_mfe(name)` template function to make it easier to write patches. (by @regisb)

--- a/tutormfe/patches/openedx-cms-development-settings
+++ b/tutormfe/patches/openedx-cms-development-settings
@@ -1,9 +1,5 @@
 # MFE-specific settings
-{% for app_name, app in iter_mfes() %}
-{% if app_name == "course-authoring" %}
-COURSE_AUTHORING_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ app["port"] }}/course-authoring"
-CORS_ORIGIN_WHITELIST.append("http://{{ MFE_HOST }}:{{ app["port"] }}")
-LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}:{{ app["port"] }}")
-CSRF_TRUSTED_ORIGINS.append("{{ MFE_HOST }}:{{ app["port"] }}")
-{% endif %}
-{% endfor %}
+COURSE_AUTHORING_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ get_mfe('course-authoring')["port"] }}/course-authoring"
+CORS_ORIGIN_WHITELIST.append("http://{{ MFE_HOST }}:{{ get_mfe('course-authoring')["port"] }}")
+LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}:{{ get_mfe('course-authoring')["port"] }}")
+CSRF_TRUSTED_ORIGINS.append("{{ MFE_HOST }}:{{ get_mfe('course-authoring')["port"] }}")

--- a/tutormfe/patches/openedx-cms-production-settings
+++ b/tutormfe/patches/openedx-cms-production-settings
@@ -1,9 +1,7 @@
 # MFE-specific settings
-{% for app_name, app in iter_mfes() %}
-{% if app_name == "course-authoring" %}
+{% if get_mfe("course-authoring") %}
 COURSE_AUTHORING_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/course-authoring"
 {% endif %}
-{% endfor %}
 
 LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}")
 CORS_ORIGIN_WHITELIST.append("{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}")

--- a/tutormfe/patches/openedx-lms-common-settings
+++ b/tutormfe/patches/openedx-lms-common-settings
@@ -5,10 +5,9 @@ ENABLE_MFE_CONFIG_API = True
 MFE_CONFIG_API_CACHE_TIMEOUT = 1
 
 # MFE-specific settings
-{% for app_name, app in iter_mfes() %}
-{% if app_name == "authn" %}
+{% if get_mfe("authn") %}
 FEATURES['ENABLE_AUTHN_MICROFRONTEND'] = True
-{% elif app_name == "communications" %}
+{% endif %}
+{% if get_mfe("communications") %}
 FEATURES['ENABLE_NEW_BULK_EMAIL_EXPERIENCE'] = True
 {% endif %}
-{% endfor %}

--- a/tutormfe/patches/openedx-lms-development-settings
+++ b/tutormfe/patches/openedx-lms-development-settings
@@ -24,35 +24,49 @@ MFE_CONFIG = {
 }
 
 # MFE-specific settings
-{% for app_name, app in iter_mfes() %}
-{% if app_name == "authn" %}
-AUTHN_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ app["port"] }}/authn"
+{% if get_mfe("authn") %}
+AUTHN_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ get_mfe("authn")["port"] }}/authn"
 AUTHN_MICROFRONTEND_DOMAIN  = "{{ MFE_HOST }}/authn"
 MFE_CONFIG["DISABLE_ENTERPRISE_LOGIN"] = True
-{% elif app_name == "account" %}
-ACCOUNT_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ app["port"] }}/account"
+{% endif %}
+
+{% if get_mfe("account") %}
+ACCOUNT_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ get_mfe("account")["port"] }}/account"
 MFE_CONFIG["ACCOUNT_SETTINGS_URL"] = ACCOUNT_MICROFRONTEND_URL
-{% elif app_name == "course-authoring" %}
+{% endif %}
+
+{% if get_mfe("course-authoring") %}
 MFE_CONFIG["ENABLE_NEW_EDITOR_PAGES"] = True
 MFE_CONFIG["ENABLE_PROGRESS_GRAPH_SETTINGS"] = True
-{% elif app_name == "discussions" %}
-DISCUSSIONS_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ app["port"] }}/discussions"
+{% endif %}
+
+{% if get_mfe("discussions") %}
+DISCUSSIONS_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ get_mfe("discussions")["port"] }}/discussions"
 DISCUSSIONS_MFE_FEEDBACK_URL = None
-{% elif app_name == "gradebook" %}
-WRITABLE_GRADEBOOK_URL = "http://{{ MFE_HOST }}:{{ app["port"] }}/gradebook"
-{% elif app_name == "learning" %}
-LEARNING_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ app["port"] }}/learning"
-MFE_CONFIG["LEARNING_BASE_URL"] = "http://{{ MFE_HOST }}:{{ app["port"] }}"
-{% elif app_name == "ora-grading" %}
-ORA_GRADING_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ app["port"] }}/ora-grading"
-{% elif app_name == "profile" %}
-PROFILE_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ app["port"] }}/profile/u/"
-MFE_CONFIG["ACCOUNT_PROFILE_URL"] = "http://{{ MFE_HOST }}:{{ app["port"] }}/profile"
-{% elif app_name == "communications" %}
-COMMUNICATIONS_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ app["port"] }}/communications"
+{% endif %}
+
+{% if get_mfe("gradebook") %}
+WRITABLE_GRADEBOOK_URL = "http://{{ MFE_HOST }}:{{ get_mfe("gradebook")["port"] }}/gradebook"
+{% endif %}
+
+{% if get_mfe("learning") %}
+LEARNING_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ get_mfe("learning")["port"] }}/learning"
+MFE_CONFIG["LEARNING_BASE_URL"] = "http://{{ MFE_HOST }}:{{ get_mfe("learning")["port"] }}"
+{% endif %}
+
+{% if get_mfe("ora-grading") %}
+ORA_GRADING_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ get_mfe("ora-grading")["port"] }}/ora-grading"
+{% endif %}
+
+{% if get_mfe("profile") %}
+PROFILE_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ get_mfe("profile")["port"] }}/profile/u/"
+MFE_CONFIG["ACCOUNT_PROFILE_URL"] = "http://{{ MFE_HOST }}:{{ get_mfe("profile")["port"] }}/profile"
+{% endif %}
+
+{% if get_mfe("communications") %}
+COMMUNICATIONS_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ get_mfe("communications")["port"] }}/communications"
 MFE_CONFIG["SCHEDULE_EMAIL_SECTION"] = True
 {% endif %}
-{% endfor %}
 
 # Cors configuration
 {% for app_name, app in iter_mfes() %}

--- a/tutormfe/patches/openedx-lms-production-settings
+++ b/tutormfe/patches/openedx-lms-production-settings
@@ -24,35 +24,50 @@ MFE_CONFIG = {
 }
 
 # MFE-specific settings
-{% for app_name, app in iter_mfes() %}
-{% if app_name == "authn" %}
+
+{% if get_mfe("authn") %}
 AUTHN_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/authn"
 AUTHN_MICROFRONTEND_DOMAIN  = "{{ MFE_HOST }}/authn"
 MFE_CONFIG["DISABLE_ENTERPRISE_LOGIN"] = True
-{% elif app_name == "account" %}
+{% endif %}
+
+{% if get_mfe("account") %}
 ACCOUNT_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/account"
 MFE_CONFIG["ACCOUNT_SETTINGS_URL"] = ACCOUNT_MICROFRONTEND_URL
-{% elif app_name == "course-authoring" %}
+{% endif %}
+
+{% if get_mfe("course-authoring") %}
 MFE_CONFIG["ENABLE_NEW_EDITOR_PAGES"] = True
 MFE_CONFIG["ENABLE_PROGRESS_GRAPH_SETTINGS"] = True
-{% elif app_name == "discussions" %}
+{% endif %}
+
+{% if get_mfe("discussions") %}
 DISCUSSIONS_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/discussions"
 DISCUSSIONS_MFE_FEEDBACK_URL = None
-{% elif app_name == "gradebook" %}
+{% endif %}
+
+{% if get_mfe("gradebook") %}
 WRITABLE_GRADEBOOK_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/gradebook"
-{% elif app_name == "learning" %}
+{% endif %}
+
+{% if get_mfe("learning") %}
 LEARNING_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/learning"
 MFE_CONFIG["LEARNING_BASE_URL"] = "{{ "https" if ENABLE_HTTPS else "http" }}://{{ MFE_HOST }}/learning"
-{% elif app_name == "ora-grading" %}
+{% endif %}
+
+{% if get_mfe("ora-grading") %}
 ORA_GRADING_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/ora-grading"
-{% elif app_name == "profile" %}
+{% endif %}
+
+{% if get_mfe("profile") %}
 PROFILE_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/profile/u/"
 MFE_CONFIG["ACCOUNT_PROFILE_URL"] = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/profile"
-{% elif app_name == "communications" %}
+{% endif %}
+
+{% if get_mfe("communications") %}
 COMMUNICATIONS_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/communications"
 MFE_CONFIG["SCHEDULE_EMAIL_SECTION"] = True
 {% endif %}
-{% endfor %}
 
 LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}")
 CORS_ORIGIN_WHITELIST.append("{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}")

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import os
 import typing as t
 from glob import glob
@@ -100,22 +101,38 @@ def _add_core_mfe_apps(apps: dict[str, MFE_ATTRS_TYPE]) -> dict[str, MFE_ATTRS_T
     return apps
 
 
+@functools.lru_cache(maxsize=None)
+def get_mfes() -> dict[str, MFE_ATTRS_TYPE]:
+    """
+    This function is cached for performance.
+    """
+    return MFE_APPS.apply({})
+
+
 def iter_mfes() -> t.Iterable[tuple[str, MFE_ATTRS_TYPE]]:
     """
     Yield:
 
         (name, dict)
     """
-    yield from MFE_APPS.apply({}).items()
+    yield from get_mfes().items()
 
 
 def is_mfe_enabled(mfe_name: str) -> bool:
-    return mfe_name in MFE_APPS.apply({})
+    return mfe_name in get_mfes()
+
+
+def get_mfe(mfe_name: str) -> MFE_ATTRS_TYPE:
+    return get_mfes().get(mfe_name, {})
 
 
 # Make the mfe functions available within templates
 tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
-    [("iter_mfes", iter_mfes), ("is_mfe_enabled", is_mfe_enabled)]
+    [
+        ("get_mfe", get_mfe),
+        ("iter_mfes", iter_mfes),
+        ("is_mfe_enabled", is_mfe_enabled),
+    ]
 )
 
 


### PR DESCRIPTION
Currently, the syntax to fetch mfe settings inside patches is very awkward:

	{% for app_name, app in iter_mfes() %}
	{% if app_name == "mymfe" %}
	...
	{% endif %}
	{% endfor %}

We introduce a new template function to make this easier:

    SOMETHING = "{{ get_mfe('mymfe')['port'] }}"

`get_mfe` is cached for performance.