### PR TITLE
fix: specify port for dev server to listen on

### DIFF
--- a/changelog.d/20231208_132545_mpwheel_mfe_dev_ports.md
+++ b/changelog.d/20231208_132545_mpwheel_mfe_dev_ports.md
@@ -1,0 +1,1 @@
+- [Bugfix] Specify port for dev server to listen on (by @michaelwheeler)

--- a/tutormfe/patches/local-docker-compose-dev-services
+++ b/tutormfe/patches/local-docker-compose-dev-services
@@ -23,5 +23,7 @@ mfe:
     restart: unless-stopped
     depends_on:
         - lms
+    environment:
+        - "PORT={{ app['port'] }}"
 {%- endif %}
 {%- endfor %}


### PR DESCRIPTION
Seems like the `PORT` environment variable was removed at some point after [v14.0.2](https://github.com/overhangio/tutor-mfe/blob/v14.0.2/tutormfe/patches/local-docker-compose-dev-services). This left development containers listening at the default port 8080, which is not forwarded to the host.