### PR TITLE
fix: append trailing slash to PUBLIC_PATH

### DIFF
--- a/changelog.d/20231206_183103_arbrandes_fix_trailing_slash.md
+++ b/changelog.d/20231206_183103_arbrandes_fix_trailing_slash.md
@@ -1,0 +1,1 @@
+- [Bugfix] Append trailing slash to PUBLIC_PATH, as its absence breaks some MFEs. (by @arbrandes)

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -79,7 +79,7 @@ EXPOSE {{ app['port'] }}
 
 # Configuration needed at build time
 ENV APP_ID={{ app_name }}
-ENV PUBLIC_PATH='/{{ app_name }}'
+ENV PUBLIC_PATH='/{{ app_name }}/'
 # We could in theory point the mfe_config API directly to the LMS. But for that we would
 # have to code the LMS url into the mfe image, and this configuration is user-dependent.
 # So we point to a relative url that will be a proxy for the LMS.


### PR DESCRIPTION
This reverts ae60b2db08ef77a5dfb42b0ec9c2671c59af08a7.  We depend heavily on Webpack's `publicPath` for everything to work in MFEs that are hosted in sub-paths.  This variable affects many things, including URLs that are automatically generated for things like static assets or lazily loaded chunks of code.  If the trailing slash is not appended to, say, `/learning`, a React.lazy() will try to fetch this from Caddy, and fail:

`/learning210.3f8d0b2a9dbf3b1f1e69.js`

While this can (and probably should) be dealt with in frontend-platform, we do it here for now.