### PR TITLE
fix: auto-build mfe image in nightly

### DIFF
--- a/changelog.d/20231208_112710_regis_nightly_auto_build_mfe.md
+++ b/changelog.d/20231208_112710_regis_nightly_auto_build_mfe.md
@@ -1,0 +1,1 @@
+- [Bugfix] Auto-build "mfe" image during `dev/local launch` in nightly. (by @regisb)

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -242,6 +242,10 @@ def _print_mfe_public_hosts(
 def _build_3rd_party_dev_mfes_on_launch(
     image_names: list[str], context_name: t.Literal["local", "dev"]
 ) -> list[str]:
+    if __version_suffix__:
+        # Build mfe image in nightly mode
+        image_names.append("mfe")
+
     for mfe_name, _mfe_attrs in iter_mfes():
         if __version_suffix__ or (
             context_name == "dev" and mfe_name not in CORE_MFE_APPS


### PR DESCRIPTION
See: https://discuss.openedx.org/t/error-response-from-daemon-manifest-for-overhangio-openedx-mfe-16-1-3-nightly-not-found/11881