### PR TITLE
feat: Enable the new discussion sidebar in the Learning MFE

### DIFF
--- a/changelog.d/20231208_142032_arbrandes_nightly.md
+++ b/changelog.d/20231208_142032_arbrandes_nightly.md
@@ -1,0 +1,1 @@
+- [Feature] Enable the new per-unit discussions sidebar in the Learning MFE. (by @arbrandes)

--- a/tutormfe/patches/openedx-lms-development-settings
+++ b/tutormfe/patches/openedx-lms-development-settings
@@ -42,6 +42,7 @@ MFE_CONFIG["ENABLE_PROGRESS_GRAPH_SETTINGS"] = True
 
 {% if get_mfe("discussions") %}
 DISCUSSIONS_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ get_mfe("discussions")["port"] }}/discussions"
+MFE_CONFIG["DISCUSSIONS_MFE_BASE_URL"] = DISCUSSIONS_MICROFRONTEND_URL
 DISCUSSIONS_MFE_FEEDBACK_URL = None
 {% endif %}
 

--- a/tutormfe/patches/openedx-lms-production-settings
+++ b/tutormfe/patches/openedx-lms-production-settings
@@ -43,6 +43,7 @@ MFE_CONFIG["ENABLE_PROGRESS_GRAPH_SETTINGS"] = True
 
 {% if get_mfe("discussions") %}
 DISCUSSIONS_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/discussions"
+MFE_CONFIG["DISCUSSIONS_MFE_BASE_URL"] = DISCUSSIONS_MICROFRONTEND_URL
 DISCUSSIONS_MFE_FEEDBACK_URL = None
 {% endif %}
 

--- a/tutormfe/templates/mfe/tasks/lms/init
+++ b/tutormfe/templates/mfe/tasks/lms/init
@@ -46,12 +46,14 @@ site-configuration unset --domain={{ LMS_HOST }}:8000 ENABLE_PROFILE_MICROFRONTE
 (./manage.py lms waffle_flag --list | grep discussions.enable_moderation_reason_codes ) || ./manage.py lms waffle_flag --create --everyone discussions.enable_moderation_reason_codes
 (./manage.py lms waffle_flag --list | grep discussions.enable_reported_content_email_notifications ) || ./manage.py lms waffle_flag --create --everyone discussions.enable_reported_content_email_notifications
 (./manage.py lms waffle_flag --list | grep discussions.enable_learners_stats ) || ./manage.py lms waffle_flag --create --everyone discussions.enable_learners_stats
+(./manage.py lms waffle_flag --list | grep discussions.enable_new_structure_discussions ) || ./manage.py lms waffle_flag --create --everyone discussions.enable_new_structure_discussions
 {% else %}
 ./manage.py lms waffle_delete --flags discussions.enable_discussions_mfe
 ./manage.py lms waffle_delete --flags discussions.enable_learners_tab_in_discussions_mfe
 ./manage.py lms waffle_delete --flags discussions.enable_moderation_reason_codes
 ./manage.py lms waffle_delete --flags discussions.enable_reported_content_email_notifications
 ./manage.py lms waffle_delete --flags discussions.enable_learners_stats
+./manage.py lms waffle_delete --flags discussions.enable_new_structure_discussions
 {% endif %}
 
 {% if is_mfe_enabled("ora-grading") %}


### PR DESCRIPTION
This is a new potential headliner for Quince.  With this, learners get the ability to start discussions on a sidebar to the right of any unit.  Like so:

![image](https://github.com/overhangio/tutor-mfe/assets/759355/92b6cd72-d6ce-43b7-9b32-d65aa2e4d000)

After this patch, any new course gets this.

Old courses need manual configuration.  For one, the `edX (new)` provider needs to be selected in the Discussions configuration, in the course's "Pages and Resources":

![image](https://github.com/overhangio/tutor-mfe/assets/759355/84e9fe98-316f-4395-8937-9378a3f6d332)

There's also some neat additional configuration, either for new or old courses:

![image](https://github.com/overhangio/tutor-mfe/assets/759355/155594ae-b758-4a06-8bf8-547d5bf2b1dd)