### PR TITLE
feat: add patch at the end of the production layer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -424,6 +424,12 @@ Example: ``mfe-dockerfile-pre-npm-install-learning`` will only apply any instruc
 
 File changed: ``tutormfe/templates/mfe/build/mfe/Dockerfile``
 
+mfe-dockerfile-production-final
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Add any instructions in the final layer. Useful for overriding the CMD or ENTRYPOINT.
+
+File changed: ``tutormfe/templates/mfe/build/mfe/Dockerfile``
+
 mfe-dockerfile-post-npm-install
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Add any instructions for after the npm install has completed. This will apply the instructions to every MFE. For an example on the usage of this patch, check out `here <#mfe-docker-post-npm-install>`_.

--- a/changelog.d/20231220_054305_moisesgsalas.add_docker_final_patch.md
+++ b/changelog.d/20231220_054305_moisesgsalas.add_docker_final_patch.md
@@ -1,0 +1,13 @@
+
+<!--
+Create a changelog entry for every new user-facing change. Please respect the following instructions:
+- Indicate breaking changes by prepending an explosion 💥 character.
+- Prefix your changes with either [Bugfix], [Improvement], [Feature], [Security], [Deprecation].
+- You may optionally append "(by @<author>)" at the end of the line, where "<author>" is either one (just one)
+of your GitHub username, real name or affiliated organization. These affiliations will be displayed in
+the release notes for every release.
+-->
+
+<!-- - 💥[Feature] Foobarize the blorginator. This breaks plugins by renaming the `FOO_DO` filter to `BAR_DO`. (by @regisb) -->
+<!-- - [Improvement] This is a non-breaking change. Life is good. (by @billgates) -->
+- [Feature] Add a new `mfe-dockerfile-production-final` patch to define additional instructions in the final image. (by @MoisesGSalas)

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -111,3 +111,5 @@ RUN mkdir -p /openedx/dist
 {% for app_name, app in iter_mfes() %}
 COPY --from={{ app_name }}-prod /openedx/app/dist /openedx/dist/{{ app_name }}
 {% endfor %}
+
+{{ patch("mfe-dockerfile-production-final") }}


### PR DESCRIPTION
# Description

The `mfe-dockerfile-production-final` patch allows you to add instructions to the end of the final layer. This is useful in the case you want to override the default CMD or ENTRYPOINT instructions.


## Additional info

I think the patch will be useful overall, but my use case is as follows:

I've been exploring the idea of pointing [`Public Path`](https://webpack.js.org/guides/public-path/) to a cloudfront endpoint to speed up the MFE asset delivery. The only problem is that I can't reuse the image between environments because the cloudfront endpoint is hardcoded at build time. What I've been playing around is to use a placeholder string as the  `PUBLIC_PATH` and run a startup script in the container that replaces the placeholder with a value set in an environment variable.