### PR TITLE
feat: add course authoring mfe base url to env vars

### DIFF
--- a/changelog.d/20240108_150445_romulo_add_course_authoring_mfe_base_url.md
+++ b/changelog.d/20240108_150445_romulo_add_course_authoring_mfe_base_url.md
@@ -1,0 +1,1 @@
+- [Improvement] Adds the "COURSE_AUTHORING_MFE_BASE_URL" env var pointing to the Course Authoring MFE address. (by @rpenido)

--- a/tutormfe/patches/openedx-lms-development-settings
+++ b/tutormfe/patches/openedx-lms-development-settings
@@ -38,6 +38,7 @@ MFE_CONFIG["ACCOUNT_SETTINGS_URL"] = ACCOUNT_MICROFRONTEND_URL
 {% if get_mfe("course-authoring") %}
 MFE_CONFIG["ENABLE_NEW_EDITOR_PAGES"] = True
 MFE_CONFIG["ENABLE_PROGRESS_GRAPH_SETTINGS"] = True
+MFE_CONFIG["COURSE_AUTHORING_MFE_BASE_URL"] = "http://{{ MFE_HOST }}:{{ get_mfe("course-authoring")["port"] }}"
 {% endif %}
 
 {% if get_mfe("discussions") %}

--- a/tutormfe/patches/openedx-lms-production-settings
+++ b/tutormfe/patches/openedx-lms-production-settings
@@ -39,6 +39,7 @@ MFE_CONFIG["ACCOUNT_SETTINGS_URL"] = ACCOUNT_MICROFRONTEND_URL
 {% if get_mfe("course-authoring") %}
 MFE_CONFIG["ENABLE_NEW_EDITOR_PAGES"] = True
 MFE_CONFIG["ENABLE_PROGRESS_GRAPH_SETTINGS"] = True
+MFE_CONFIG["COURSE_AUTHORING_MFE_BASE_URL"] = "http://{{ MFE_HOST }}:{{ get_mfe("course-authoring")["port"] }}"
 {% endif %}
 
 {% if get_mfe("discussions") %}


### PR DESCRIPTION
## Description

This PR adds the "COURSE_AUTHORING_MFE_BASE_URL" env var pointing to the Course Authoring MFE address.

## Additional Info
We are rendering a course authoring URL in an iFrame inside the library authoring as part of the Tagging Project, so we need to know the Course Authoring MFE address.
- https://github.com/openedx/frontend-app-library-authoring/pull/400