### PR TITLE
docs: add warning to adding new MFEs section of the README about the MFE plugin URL ending in .git

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,18 +126,21 @@ MFE management
 Adding new MFEs
 ~~~~~~~~~~~~~~~
 
-.. warning:: As of Tutor v16 (Palm release) it is no longer possible to add new MFEs by creating ``*_MFE_APP`` settings. Instead, users must implement the approach described here.
+⚠️ **Warnings**
 
-Other MFE developers can take advantage of this plugin to deploy their own MFEs. To declare a new MFE, create a Tutor plugin and add your MFE configuration to the ``tutormfe.hooks.MFE_APPS`` filter. This configuration should include the name, git repository (and optionally: git branch) and development port. For example::
+- As of Tutor v16 (Palm release) it is no longer possible to add new MFEs by creating ``*_MFE_APP`` settings. Instead, users must implement the approach described below.
+- As of Tutor v17 (Quince release) you must make sure that the git URL of your MFE repository ends with ``.git``. Otherwise the plugin build will fail.
+
+Other MFE developers can take advantage of this plugin to deploy their own MFEs. To declare a new MFE, create a Tutor plugin and add your MFE configuration to the ``tutormfe.hooks.MFE_APPS`` filter. This configuration should include the name, git repository (and optionally: git branch or tag) and development port. For example::
 
     from tutormfe.hooks import MFE_APPS
 
     @MFE_APPS.add()
     def _add_my_mfe(mfes):
         mfes["mymfe"] = {
-            "repository": "https://github.com/myorg/mymfe",
+            "repository": "https://github.com/myorg/mymfe.git",
             "port": 2001,
-            "version": "me/my-custom-branch", # optional, will default to the Open edX current tag.
+            "version": "me/my-custom-branch-or-tag", # optional, will default to the Open edX current tag.
         }
         return mfes
 


### PR DESCRIPTION
As of Tutor v17 (Quince release) custom MFE plugins only accept URLs ending in `.git`. Providing a normal URL of the repository will cause failure in the build of MFE image when running `tutor images build mfe` as the custom MFE won't get cloned. 

This issue was previously mentioned [in this topic](https://discuss.openedx.org/t/rebuilding-mfes-with-a-custom-fork/11918) and the changelog was updated in [this PR](https://github.com/overhangio/tutor-mfe/pull/178). This PR updates the readme.

Closes https://github.com/overhangio/tutor-mfe/issues/180