### PR TITLE
fix: Issue MFE_HOST url redirects to LMS_HOST 

### DIFF
--- a/changelog.d/20240220_180043_hina.khadim_mfe_url_issue.md
+++ b/changelog.d/20240220_180043_hina.khadim_mfe_url_issue.md
@@ -1,0 +1,1 @@
+- [BugFix] Fix issue of MFE_HOST url redirection to LMS_HOST (by @hinakhadim)

--- a/tutormfe/patches/caddyfile
+++ b/tutormfe/patches/caddyfile
@@ -1,5 +1,5 @@
 {{ MFE_HOST }}{$default_site_port} {
-    respond / 204
+    redir / {% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ LMS_HOST }}
     request_body {
         max_size 2MB
     }


### PR DESCRIPTION
This PR resolves the #185 . The MFE_HOST url without any MFE name in url redirects to the LMS_HOST url. Before it, the MFE_HOST responds with 204.