### PR TITLE
fix: Runtime config in dev mode

### DIFF
--- a/changelog.d/20240206_100528_arbrandes_fix_dev_runtime_config.md
+++ b/changelog.d/20240206_100528_arbrandes_fix_dev_runtime_config.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix MFE runtime config via site configuration in dev mode (by @arbrandes).

--- a/tutormfe/templates/mfe/apps/mfe/webpack.dev-tutor.config.js
+++ b/tutormfe/templates/mfe/apps/mfe/webpack.dev-tutor.config.js
@@ -15,7 +15,10 @@ module.exports = merge(baseDevConfig, {
     // https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md
     allowedHosts: 'all',
     proxy: {
-      '/api/mfe_config/v1' : 'http://{{ LMS_HOST }}:8000',
+      '/api/mfe_config/v1': {
+        target: 'http://{{ LMS_HOST }}:8000',
+        changeOrigin: true,
+      }
     }
   },
 })


### PR DESCRIPTION
### Description

MFE runtime configuration in dev mode was not working properly prior to this.  It would always end up querying the `example.com` site configuration.  With this change, we force the request origin to always be the LMS host and port, as opposed to something like `apps.local.edly.io:2001`, which would trip up the Django site detection.

### Reproducing and testing

To reproduce (and test) the problem:

1. Check out an MFE locally.  For instance, the learner dashboard: `git clone https://github.com/openedx/frontend-app-learner-dashboard`
2. Configure a local mount for the MFE.  `tutor mounts add ./frontend-app-learner-dashboard`
3. Launch Tutor in dev mode: `tutor dev launch`.  (This should rebuild the appropriate images.)
4. Go to the site configuration admin page (http://local.edly.io:8000/admin/site_configuration/siteconfiguration/), and under the `local.edly.io:8000` entry, add an override for the dashboard such as:

```
{
    "MFE_CONFIG_OVERRIDES": {
       "learner-dashboard": {
            "BOGUS": true
        }
    }
}
```

5. Navigate to the MFE in a browser (http://apps.local.edly.io:1996/learner-dashboard/).  Open the Network tab in the debug console, and find the "mfe_config" request. (The URL should be "http://apps.local.edly.io:1996/api/mfe_config/v1?mfe=learner-dashboard".)  Click on it, and then on the "Response" tab.  If the "BOGUS" entry is not in the configuration object, you have successfully reproduced the problem.

To test the fix, check out this branch, save configuration, (`tutor config save`), rebuild the learner dashboard dev image with `tutor images build learner-dashboard-dev`, and restart the dev environment.  You should then be able to see the "BOGUS" entry.

### Further information

For reference on `changeOrigin`, see https://webpack.js.org/configuration/dev-server/#devserverproxy and https://github.com/chimurai/http-proxy-middleware?tab=readme-ov-file#http-proxy-options.