### PR TITLE
fix: allow removal of course-authoring mfe

### DIFF
--- a/changelog.d/20240213_141934_danyal.faheem_fix_course_authoring_mfe_removal.md
+++ b/changelog.d/20240213_141934_danyal.faheem_fix_course_authoring_mfe_removal.md
@@ -1,0 +1,1 @@
+[Bugfix] Make sure course-authoring mfe is present in MFE_APPS before applying cms-development-settings. (by @Danyal-Faheem)

--- a/tutormfe/patches/openedx-cms-development-settings
+++ b/tutormfe/patches/openedx-cms-development-settings
@@ -1,5 +1,7 @@
 # MFE-specific settings
+{% if get_mfe("course-authoring") %}
 COURSE_AUTHORING_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ get_mfe('course-authoring')["port"] }}/course-authoring"
 CORS_ORIGIN_WHITELIST.append("http://{{ MFE_HOST }}:{{ get_mfe('course-authoring')["port"] }}")
 LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}:{{ get_mfe('course-authoring')["port"] }}")
 CSRF_TRUSTED_ORIGINS.append("http://{{ MFE_HOST }}:{{ get_mfe('course-authoring')["port"] }}")
+{% endif %}


### PR DESCRIPTION
Fixes #189.

Added a small check to make sure `course-authoring` is in the `MFE_APPS` before changing the settings.