### PR TITLE
ci: add learner-dashbaord-dev image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 variables:
     TUTOR_PLUGIN: mfe
-    TUTOR_IMAGES: mfe authn-dev account-dev communications-dev course-authoring-dev discussions-dev gradebook-dev learning-dev ora-grading-dev profile-dev learner-dashboard-dev
+    TUTOR_IMAGES: mfe authn-dev account-dev communications-dev course-authoring-dev discussions-dev gradebook-dev learner-dashboard-dev learning-dev ora-grading-dev profile-dev
     TUTOR_PYPI_PACKAGE: tutor-mfe
     OPENEDX_RELEASE: palm
     GITHUB_REPO: overhangio/tutor-mfe

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 variables:
     TUTOR_PLUGIN: mfe
-    TUTOR_IMAGES: mfe authn-dev account-dev communications-dev course-authoring-dev discussions-dev gradebook-dev learning-dev ora-grading-dev profile-dev
+    TUTOR_IMAGES: mfe authn-dev account-dev communications-dev course-authoring-dev discussions-dev gradebook-dev learning-dev ora-grading-dev profile-dev learner-dashboard-dev
     TUTOR_PYPI_PACKAGE: tutor-mfe
     OPENEDX_RELEASE: palm
     GITHUB_REPO: overhangio/tutor-mfe

--- a/changelog.d/20240221_114505_danyal.faheem_add_learner_dashboard_dev_to_ci.md
+++ b/changelog.d/20240221_114505_danyal.faheem_add_learner_dashboard_dev_to_ci.md
@@ -1,0 +1,1 @@
+[Bugfix] Added the learner-dashboard-dev image to the gitlab ci. (by @Danyal-Faheem)

--- a/changelog.d/20240221_114505_danyal.faheem_add_learner_dashboard_dev_to_ci.md
+++ b/changelog.d/20240221_114505_danyal.faheem_add_learner_dashboard_dev_to_ci.md
@@ -1,1 +1,1 @@
-[Bugfix] Added the learner-dashboard-dev image to the gitlab ci. (by @Danyal-Faheem)
+-[Bugfix] Added the learner-dashboard-dev image to the gitlab ci. (by @Danyal-Faheem)


### PR DESCRIPTION
Fixes #188. 

Added the `learner-dashboard-dev` image to the gitlab-ci so it can be pushed to the overhangio dockerhub repository.