### PR TITLE
fix: dev mode after frontend-build namespace change

### DIFF
--- a/changelog.d/20240228_111818_arbrandes_nightly.md
+++ b/changelog.d/20240228_111818_arbrandes_nightly.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix dev mode after frontend-build NPM namespace change (by @arbrandes)

--- a/tutormfe/templates/mfe/apps/mfe/webpack.dev-tutor.config.js
+++ b/tutormfe/templates/mfe/apps/mfe/webpack.dev-tutor.config.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const baseDevConfig = (
   fs.existsSync('./webpack.dev.config.js')
     ? require('./webpack.dev.config.js')
-    : require('@edx/frontend-build/config/webpack.dev.config.js')
+    : require('@openedx/frontend-build/config/webpack.dev.config.js')
 );
 
 module.exports = merge(baseDevConfig, {


### PR DESCRIPTION
Only affects master development builds, so should go into nightly.  See openedx/axim-engineering#23.