### PR TITLE
fix: add missing curly braces

### DIFF
--- a/changelog.d/20240305_113936_moises.gonzalez_fix_dev_settings_rendering.md
+++ b/changelog.d/20240305_113936_moises.gonzalez_fix_dev_settings_rendering.md
@@ -1,0 +1,1 @@
+- [Bugfix] add a missing curly braces in the openedx-lms-development-settings patch

--- a/tutormfe/patches/openedx-lms-development-settings
+++ b/tutormfe/patches/openedx-lms-development-settings
@@ -38,7 +38,7 @@ MFE_CONFIG["ACCOUNT_SETTINGS_URL"] = ACCOUNT_MICROFRONTEND_URL
 {% if get_mfe("course-authoring") %}
 MFE_CONFIG["ENABLE_NEW_EDITOR_PAGES"] = True
 MFE_CONFIG["ENABLE_PROGRESS_GRAPH_SETTINGS"] = True
-MFE_CONFIG["COURSE_AUTHORING_MICROFRONTEND_URL"] = "http://{{ MFE_HOST }}:{{ get_mfe("course-authoring")["port"]/course-authoring"
+MFE_CONFIG["COURSE_AUTHORING_MICROFRONTEND_URL"] = "http://{{ MFE_HOST }}:{{ get_mfe("course-authoring")["port"] }}/course-authoring"
 {% endif %}
 
 {% if get_mfe("discussions") %}


### PR DESCRIPTION
# Description

The `openedx-lms-development-settings` was missing the closing braces and caused an error when rendering.