### PR TITLE
feat: switch to new Files & Uploads page

### DIFF
--- a/tutormfe/templates/mfe/tasks/lms/init
+++ b/tutormfe/templates/mfe/tasks/lms/init
@@ -30,6 +30,7 @@ site-configuration unset --domain={{ LMS_HOST }}:8000 ENABLE_PROFILE_MICROFRONTE
 
 {% if is_mfe_enabled("course-authoring") %}
 (./manage.py lms waffle_flag --list | grep discussions.pages_and_resources_mfe) || ./manage.py lms waffle_flag --create --everyone discussions.pages_and_resources_mfe
+(./manage.py lms waffle_flag --list | grep contentstore.new_studio_mfe.use_new_files_uploads_page) || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_files_uploads_page
 (./manage.py lms waffle_flag --list | grep new_core_editors.use_new_text_editor) || ./manage.py lms waffle_flag --create --deactivate new_core_editors.use_new_text_editor
 (./manage.py lms waffle_flag --list | grep new_core_editors.use_new_video_editor) || ./manage.py lms waffle_flag --create --deactivate new_core_editors.use_new_video_editor
 (./manage.py lms waffle_flag --list | grep new_core_editors.use_new_problem_editor) || ./manage.py lms waffle_flag --create --deactivate new_core_editors.use_new_problem_editor
@@ -38,6 +39,7 @@ site-configuration unset --domain={{ LMS_HOST }}:8000 ENABLE_PROFILE_MICROFRONTE
 ./manage.py lms waffle_delete --flags new_core_editors.use_new_text_editor
 ./manage.py lms waffle_delete --flags new_core_editors.use_new_video_editor
 ./manage.py lms waffle_delete --flags new_core_editors.use_new_problem_editor
+./manage.py lms waffle_delete --flags contentstore.new_studio_mfe.use_new_files_uploads_page
 {% endif %}
 
 {% if is_mfe_enabled("discussions") %}


### PR DESCRIPTION
## Status

This is a draft, for now. I'll wrap it up and propose it for merging before Redwood so that the [removal of studio-frontend](https://github.com/openedx/studio-frontend/issues/381) can move forward.

TODOs for me:

* add this to the release notes
* test this
* screenshots
 
## Description

In Studio, this switches from the Django-rendered Files & Uploads page to the new version of the page in the course-authoring MFE. 

Operators can opt-out for Redwood by disabling the `contentstore.new_studio_mfe.use_new_files_uploads_page` flag, either per-course or site-wide. Operators can also still disable the course-authoring MFE entirely. However, starting in Sumac, this option will be removed for the Files & Uploads page (and potentially for other pages) so we recommend that operators switch to the new page during Redwood.

Part of: https://github.com/openedx/studio-frontend/issues/381

## Testing

TBD