### PR TITLE
fix: serve authoring static files in dev mode

### DIFF
--- a/tutormfe/templates/mfe/apps/mfe/webpack.dev-tutor.config.js
+++ b/tutormfe/templates/mfe/apps/mfe/webpack.dev-tutor.config.js
@@ -23,4 +23,25 @@ module.exports = merge(baseDevConfig, {
   },
 })
 
+// Serve frontend-app-course-authoring's XBlock bootstrap files statically.
+if (fs.existsSync("src/course-unit/course-xblock/xblock-content/iframe-wrapper/static/xblock-bootstrap.html")) {
+  const path = require('path');
+  const CopyPlugin = require('copy-webpack-plugin');
+
+  module.exports.plugins.push(
+    new CopyPlugin({
+      patterns: [
+        {
+          context: path.resolve(__dirname, 'src/course-unit/course-xblock/xblock-content/iframe-wrapper/static'),
+          from: 'xblock-bootstrap.html',
+        },
+        {
+          context: path.resolve(__dirname, 'src/course-unit/course-xblock/xblock-content/iframe-wrapper/static'),
+          from: 'XBlockIFrame.css',
+        },
+      ],
+    }),
+  );
+}
+
 {{ patch("mfe-webpack-dev-config") }}


### PR DESCRIPTION
The new Studio implementation in MFE-land requires rendering XBlocks in iframes.  If we want it to work in dev mode, we need to change Tutor's webpack dev config to match upstream's (as per https://github.com/openedx/frontend-app-course-authoring/pull/964/files#diff-03651daa986b59c8421cba91a0ff6e7ffdfc40623e571f6525f648c2a6e19308).

This is draft mode until that PR is merged.