### PR TITLE
feat: add new learning mfe toggles for navigation sidebar

### DIFF
--- a/tutormfe/templates/mfe/tasks/lms/init
+++ b/tutormfe/templates/mfe/tasks/lms/init
@@ -24,8 +24,12 @@ site-configuration unset --domain={{ LMS_HOST }}:8000 ENABLE_PROFILE_MICROFRONTE
 
 {% if is_mfe_enabled("learning") %}
 (./manage.py lms waffle_flag --list | grep course_home.course_home_mfe_progress_tab) || ./manage.py lms waffle_flag --create --everyone course_home.course_home_mfe_progress_tab
+(./manage.py lms waffle_flag --list | grep courseware.enable_navigation_sidebar) || ./manage.py lms waffle_flag --create --deactivate courseware.enable_navigation_sidebar
+(./manage.py lms waffle_flag --list | grep courseware.always_open_auxiliary_sidebar) || ./manage.py lms waffle_flag --create --deactivate courseware.always_open_auxiliary_sidebar
 {% else %}
 ./manage.py lms waffle_delete --flags course_home.course_home_mfe_progress_tab
+./manage.py lms waffle_delete --flags courseware.enable_navigation_sidebar
+./manage.py lms waffle_delete --flags courseware.always_open_auxiliary_sidebar
 {% endif %}
 
 {% if is_mfe_enabled("course-authoring") %}


### PR DESCRIPTION
Adding optional toggle for redwood release, that is disabled by default for enhanced discoverability.

**Waffle toggles:** `courseware.enable_navigation_sidebar`, `courseware.always_open_auxiliary_sidebar`


For more information refer to **What should be off by default, BUT include clear documentation on how-to enable?** section in https://github.com/openedx/platform-roadmap/issues/357