### PR TITLE
feat: introduce a patch for the Docker base layer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -438,6 +438,13 @@ Add any configurations at the end of the development webpack config file in Java
 
 File changed: ``tutormfe/templates/mfe/apps/mfe/webpack.dev-tutor.config.js``
 
+mfe-dockerfile-base
+~~~~~~~~~~~~~~~~~~~
+
+Add Dockerfile instructions that will be applied to the base layer of the "mfe" image. This base layer is used both in production and development, for all applications.
+
+File changed: ``tutormfe/templates/mfe/build/mfe/Dockerfile``
+
 mfe-dockerfile-pre-npm-install
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/changelog.d/20240614_162207_regis_patch_dockerfile_common.md
+++ b/changelog.d/20240614_162207_regis_patch_dockerfile_common.md
@@ -1,0 +1,1 @@
+- [Feature] Introduce a "mfe-dockerfile-base" patch to customise the base layer of the "mfe" Docker image. (by @regisb)

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -20,6 +20,8 @@ RUN mkdir -p /openedx/app /openedx/env
 WORKDIR /openedx/app
 ENV PATH=/openedx/app/node_modules/.bin:${PATH}
 
+{{ patch("mfe-dockerfile-base") }}
+
 {% for app_name, app in iter_mfes() %}
 ####################### {{ app_name }} MFE
 ######## {{ app_name }} (git)


### PR DESCRIPTION
This patch allows the customisation of the mfe base layer. Without it, we have to apply changes to the "mfe-dockerfile-pre-npm-install" patch, and that means re-apply changes for every single MFE.