### PR TITLE
feat: faster init by avoiding repeated waffle flag listing

### DIFF
--- a/changelog.d/20240726_181354_regis_faster_init.md
+++ b/changelog.d/20240726_181354_regis_faster_init.md
@@ -1,0 +1,1 @@
+- [Improvement] Faster initialisation by optimising waffle flag listing and creation. (by @regisb)

--- a/tutormfe/templates/mfe/tasks/lms/init
+++ b/tutormfe/templates/mfe/tasks/lms/init
@@ -1,13 +1,15 @@
 # MFE-specific tasks
+./manage.py lms waffle_flag --list > /tmp/lms_waffle_flags.txt
+
 {% if is_mfe_enabled("account") %}
-(./manage.py lms waffle_flag --list | grep account.redirect_to_microfrontend) || ./manage.py lms waffle_flag --create --everyone account.redirect_to_microfrontend
+grep account.redirect_to_microfrontend /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone account.redirect_to_microfrontend
 ./manage.py lms populate_retirement_states
 {% else %}
 ./manage.py lms waffle_delete --flags account.redirect_to_microfrontend
 {% endif %}
 
 {% if is_mfe_enabled("profile") %}
-(./manage.py lms waffle_flag --list | grep learner_profile.redirect_to_microfrontend) || ./manage.py lms waffle_flag --create --everyone learner_profile.redirect_to_microfrontend
+grep learner_profile.redirect_to_microfrontend /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone learner_profile.redirect_to_microfrontend
 site-configuration set --domain={{ LMS_HOST }} ENABLE_PROFILE_MICROFRONTEND true
 site-configuration set --domain={{ LMS_HOST }}:8000 ENABLE_PROFILE_MICROFRONTEND true
 {% else %}
@@ -17,81 +19,84 @@ site-configuration unset --domain={{ LMS_HOST }}:8000 ENABLE_PROFILE_MICROFRONTE
 {% endif %}
 
 {% if is_mfe_enabled("learner-dashboard") %}
-(./manage.py lms waffle_flag --list | grep learner_home_mfe.enabled) || ./manage.py lms waffle_flag learner_home_mfe.enabled --create --everyone
+grep learner_home_mfe.enabled /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone learner_home_mfe.enabled
 {% else %}
 ./manage.py lms waffle_delete --flags learner_home_mfe.enabled
 {% endif %}
 
 {% if is_mfe_enabled("learning") %}
-(./manage.py lms waffle_flag --list | grep course_home.course_home_mfe_progress_tab) || ./manage.py lms waffle_flag --create --everyone course_home.course_home_mfe_progress_tab
-(./manage.py lms waffle_flag --list | grep courseware.enable_navigation_sidebar) || ./manage.py lms waffle_flag --create --deactivate courseware.enable_navigation_sidebar
-(./manage.py lms waffle_flag --list | grep courseware.always_open_auxiliary_sidebar) || ./manage.py lms waffle_flag --create --deactivate courseware.always_open_auxiliary_sidebar
+grep course_home.course_home_mfe_progress_tab /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone course_home.course_home_mfe_progress_tab
+grep courseware.enable_navigation_sidebar /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --deactivate courseware.enable_navigation_sidebar
+grep courseware.always_open_auxiliary_sidebar /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --deactivate courseware.always_open_auxiliary_sidebar
 {% else %}
-./manage.py lms waffle_delete --flags course_home.course_home_mfe_progress_tab
-./manage.py lms waffle_delete --flags courseware.enable_navigation_sidebar
-./manage.py lms waffle_delete --flags courseware.always_open_auxiliary_sidebar
+./manage.py lms waffle_delete --flags \
+    course_home.course_home_mfe_progress_tab \
+    courseware.enable_navigation_sidebar \
+    courseware.always_open_auxiliary_sidebar
 {% endif %}
 
 {% if is_mfe_enabled("course-authoring") %}
-(./manage.py lms waffle_flag --list | grep contentstore.new_studio_mfe.use_new_advanced_settings_page) || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_advanced_settings_page
-(./manage.py lms waffle_flag --list | grep contentstore.new_studio_mfe.use_new_certificates_page) || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_certificates_page
-(./manage.py lms waffle_flag --list | grep contentstore.new_studio_mfe.use_new_course_outline_page) || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_course_outline_page
-(./manage.py lms waffle_flag --list | grep contentstore.new_studio_mfe.use_new_course_team_page) || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_course_team_page
-(./manage.py lms waffle_flag --list | grep contentstore.new_studio_mfe.use_new_custom_pages) || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_custom_pages
-(./manage.py lms waffle_flag --list | grep contentstore.new_studio_mfe.use_new_export_page) || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_export_page
-(./manage.py lms waffle_flag --list | grep contentstore.new_studio_mfe.use_new_files_uploads_page) || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_files_uploads_page
-(./manage.py lms waffle_flag --list | grep contentstore.new_studio_mfe.use_new_grading_page) || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_grading_page
-(./manage.py lms waffle_flag --list | grep contentstore.new_studio_mfe.use_new_group_configurations_page) || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_group_configurations_page
-(./manage.py lms waffle_flag --list | grep contentstore.new_studio_mfe.use_new_import_page) || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_import_page
-(./manage.py lms waffle_flag --list | grep contentstore.new_studio_mfe.use_new_schedule_details_page) || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_schedule_details_page
-(./manage.py lms waffle_flag --list | grep contentstore.new_studio_mfe.use_new_textbooks_page) || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_textbooks_page
-(./manage.py lms waffle_flag --list | grep contentstore.new_studio_mfe.use_new_updates_page) || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_updates_page
-(./manage.py lms waffle_flag --list | grep discussions.pages_and_resources_mfe) || ./manage.py lms waffle_flag --create --everyone discussions.pages_and_resources_mfe
-(./manage.py lms waffle_flag --list | grep new_core_editors.use_new_problem_editor) || ./manage.py lms waffle_flag --create --everyone new_core_editors.use_new_problem_editor
-(./manage.py lms waffle_flag --list | grep new_core_editors.use_new_text_editor) || ./manage.py lms waffle_flag --create --everyone new_core_editors.use_new_text_editor
-(./manage.py lms waffle_flag --list | grep new_core_editors.use_new_video_editor) || ./manage.py lms waffle_flag --create --everyone new_core_editors.use_new_video_editor
-(./manage.py lms waffle_flag --list | grep new_studio_mfe.use_new_home_page) || ./manage.py lms waffle_flag --create --everyone new_studio_mfe.use_new_home_page
-(./manage.py lms waffle_flag --list | grep new_studio_mfe.use_tagging_taxonomy_list_page) || ./manage.py lms waffle_flag --create --everyone new_studio_mfe.use_tagging_taxonomy_list_page
+grep contentstore.new_studio_mfe.use_new_advanced_settings_page /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_advanced_settings_page
+grep contentstore.new_studio_mfe.use_new_certificates_page /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_certificates_page
+grep contentstore.new_studio_mfe.use_new_course_outline_page /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_course_outline_page
+grep contentstore.new_studio_mfe.use_new_course_team_page /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_course_team_page
+grep contentstore.new_studio_mfe.use_new_custom_pages /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_custom_pages
+grep contentstore.new_studio_mfe.use_new_export_page /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_export_page
+grep contentstore.new_studio_mfe.use_new_files_uploads_page /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_files_uploads_page
+grep contentstore.new_studio_mfe.use_new_grading_page /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_grading_page
+grep contentstore.new_studio_mfe.use_new_group_configurations_page /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_group_configurations_page
+grep contentstore.new_studio_mfe.use_new_import_page /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_import_page
+grep contentstore.new_studio_mfe.use_new_schedule_details_page /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_schedule_details_page
+grep contentstore.new_studio_mfe.use_new_textbooks_page /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_textbooks_page
+grep contentstore.new_studio_mfe.use_new_updates_page /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone contentstore.new_studio_mfe.use_new_updates_page
+grep discussions.pages_and_resources_mfe /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone discussions.pages_and_resources_mfe
+grep new_core_editors.use_new_problem_editor /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone new_core_editors.use_new_problem_editor
+grep new_core_editors.use_new_text_editor /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone new_core_editors.use_new_text_editor
+grep new_core_editors.use_new_video_editor /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone new_core_editors.use_new_video_editor
+grep new_studio_mfe.use_new_home_page /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone new_studio_mfe.use_new_home_page
+grep new_studio_mfe.use_tagging_taxonomy_list_page /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone new_studio_mfe.use_tagging_taxonomy_list_page
 {% else %}
-./manage.py lms waffle_delete --flags contentstore.new_studio_mfe.use_new_advanced_settings_page
-./manage.py lms waffle_delete --flags contentstore.new_studio_mfe.use_new_certificates_page
-./manage.py lms waffle_delete --flags contentstore.new_studio_mfe.use_new_course_outline_page
-./manage.py lms waffle_delete --flags contentstore.new_studio_mfe.use_new_course_team_page
-./manage.py lms waffle_delete --flags contentstore.new_studio_mfe.use_new_custom_pages
-./manage.py lms waffle_delete --flags contentstore.new_studio_mfe.use_new_export_page
-./manage.py lms waffle_delete --flags contentstore.new_studio_mfe.use_new_files_uploads_page
-./manage.py lms waffle_delete --flags contentstore.new_studio_mfe.use_new_grading_page
-./manage.py lms waffle_delete --flags contentstore.new_studio_mfe.use_new_group_configurations_page
-./manage.py lms waffle_delete --flags contentstore.new_studio_mfe.use_new_import_page
-./manage.py lms waffle_delete --flags contentstore.new_studio_mfe.use_new_schedule_details_page
-./manage.py lms waffle_delete --flags contentstore.new_studio_mfe.use_new_textbooks_page
-./manage.py lms waffle_delete --flags contentstore.new_studio_mfe.use_new_updates_page
-./manage.py lms waffle_delete --flags discussions.pages_and_resources_mfe
-./manage.py lms waffle_delete --flags new_core_editors.use_new_problem_editor
-./manage.py lms waffle_delete --flags new_core_editors.use_new_text_editor
-./manage.py lms waffle_delete --flags new_core_editors.use_new_video_editor
-./manage.py lms waffle_delete --flags new_studio_mfe.use_new_home_page
-./manage.py lms waffle_delete --flags new_studio_mfe.use_tagging_taxonomy_list_page
+./manage.py lms waffle_delete --flags \
+    contentstore.new_studio_mfe.use_new_advanced_settings_page \
+    contentstore.new_studio_mfe.use_new_certificates_page \
+    contentstore.new_studio_mfe.use_new_course_outline_page \
+    contentstore.new_studio_mfe.use_new_course_team_page \
+    contentstore.new_studio_mfe.use_new_custom_pages \
+    contentstore.new_studio_mfe.use_new_export_page \
+    contentstore.new_studio_mfe.use_new_files_uploads_page \
+    contentstore.new_studio_mfe.use_new_grading_page \
+    contentstore.new_studio_mfe.use_new_group_configurations_page \
+    contentstore.new_studio_mfe.use_new_import_page \
+    contentstore.new_studio_mfe.use_new_schedule_details_page \
+    contentstore.new_studio_mfe.use_new_textbooks_page \
+    contentstore.new_studio_mfe.use_new_updates_page \
+    discussions.pages_and_resources_mfe \
+    new_core_editors.use_new_problem_editor \
+    new_core_editors.use_new_text_editor \
+    new_core_editors.use_new_video_editor \
+    new_studio_mfe.use_new_home_page \
+    new_studio_mfe.use_tagging_taxonomy_list_page
 {% endif %}
 
 {% if is_mfe_enabled("discussions") %}
-(./manage.py lms waffle_flag --list | grep discussions.enable_discussions_mfe ) || ./manage.py lms waffle_flag --create --everyone discussions.enable_discussions_mfe
-(./manage.py lms waffle_flag --list | grep discussions.enable_learners_tab_in_discussions_mfe ) || ./manage.py lms waffle_flag --create --everyone discussions.enable_learners_tab_in_discussions_mfe
-(./manage.py lms waffle_flag --list | grep discussions.enable_moderation_reason_codes ) || ./manage.py lms waffle_flag --create --everyone discussions.enable_moderation_reason_codes
-(./manage.py lms waffle_flag --list | grep discussions.enable_reported_content_email_notifications ) || ./manage.py lms waffle_flag --create --everyone discussions.enable_reported_content_email_notifications
-(./manage.py lms waffle_flag --list | grep discussions.enable_learners_stats ) || ./manage.py lms waffle_flag --create --everyone discussions.enable_learners_stats
-(./manage.py lms waffle_flag --list | grep discussions.enable_new_structure_discussions ) || ./manage.py lms waffle_flag --create --everyone discussions.enable_new_structure_discussions
+grep discussions.enable_discussions_mfe  /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone discussions.enable_discussions_mfe
+grep discussions.enable_learners_tab_in_discussions_mfe  /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone discussions.enable_learners_tab_in_discussions_mfe
+grep discussions.enable_moderation_reason_codes  /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone discussions.enable_moderation_reason_codes
+grep discussions.enable_reported_content_email_notifications  /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone discussions.enable_reported_content_email_notifications
+grep discussions.enable_learners_stats  /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone discussions.enable_learners_stats
+grep discussions.enable_new_structure_discussions  /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone discussions.enable_new_structure_discussions
 {% else %}
-./manage.py lms waffle_delete --flags discussions.enable_discussions_mfe
-./manage.py lms waffle_delete --flags discussions.enable_learners_tab_in_discussions_mfe
-./manage.py lms waffle_delete --flags discussions.enable_moderation_reason_codes
-./manage.py lms waffle_delete --flags discussions.enable_reported_content_email_notifications
-./manage.py lms waffle_delete --flags discussions.enable_learners_stats
-./manage.py lms waffle_delete --flags discussions.enable_new_structure_discussions
+./manage.py lms waffle_delete --flags \
+    discussions.enable_discussions_mfe \
+    discussions.enable_learners_tab_in_discussions_mfe \
+    discussions.enable_moderation_reason_codes \
+    discussions.enable_reported_content_email_notifications \
+    discussions.enable_learners_stats \
+    discussions.enable_new_structure_discussions
 {% endif %}
 
 {% if is_mfe_enabled("ora-grading") %}
-(./manage.py lms waffle_flag --list | grep openresponseassessment.enhanced_staff_grader) || ./manage.py lms waffle_flag --create --everyone openresponseassessment.enhanced_staff_grader
+grep openresponseassessment.enhanced_staff_grader /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone openresponseassessment.enhanced_staff_grader
 {% else %}
 ./manage.py lms waffle_delete --flags openresponseassessment.enhanced_staff_grader
 {% endif %}


### PR DESCRIPTION
Calling `./manage.py lms waffle_flag --list` so many times causes the MFE initialisation step to take a very long time, because `./manage.py lms` is very slow. We avoid this by listing existing waffle flags in a temporary file.

On an already initialized system, `tutor local do init --limit=mfe`
drops from 3min 27s to 25s.