### PR TITLE
fix: add account mfe patch to show account page

### DIFF
--- a/changelog.d/20240820_112614_hina.khadim_account_mfe_patch.md
+++ b/changelog.d/20240820_112614_hina.khadim_account_mfe_patch.md
@@ -1,0 +1,1 @@
+- [BugFix] Add upstream footer-slot patch in account-mfe (by @hinakhadim)

--- a/changelog.d/20240820_112614_hina.khadim_account_mfe_patch.md
+++ b/changelog.d/20240820_112614_hina.khadim_account_mfe_patch.md
@@ -1,1 +1,1 @@
-- [BugFix] Add upstream footer-slot patch in account-mfe (by @hinakhadim)
+- [BugFix] Patched account-mfe from upstream to ensure it installs footer v14 via the footer-slot, enabling the installation of the custom footer. (by @hinakhadim)

--- a/tutormfe/patches/mfe-dockerfile-pre-npm-build-account
+++ b/tutormfe/patches/mfe-dockerfile-pre-npm-build-account
@@ -1,0 +1,4 @@
+RUN git config --global user.email "tutor@overhang.io" \
+  && git config --global user.name "Tutor"
+  
+RUN curl -fsSL https://github.com/openedx/frontend-app-account/commit/16fb3a1bb4c00d2b60ec3686001814461437e3a5.patch | git am


### PR DESCRIPTION
Issue:
With Tutor v18 and Tutor Indigo v18.1.0, users are unable to view the accounts page. Tutor Indigo v18.1.0 has installation of custom indigo header and footer in learning, dashboard, profile, discussion and account MFE. All MFEs are compatible with indigo header and footer except accounts MFE. The reason is:

In redwood:
Most of the MFEs using ----> footer v14

footer is installed via @openedx/frontend-slot-footer package
footer is imported like import FooterSlot from '@openedx/frontend-slot-footer';
Account MFE -----> footer v13

footer is installed via @edx/frontend-component-footer
footer is imported like import { FooterSlot } from '@edx/frontend-component-footer';
Our indigo footer is created from footer v14 and we are installing it in all MFEs (account MFE has footer v13). More details can be found on https://github.com/openedx/frontend-app-account/issues/1071

This PR adds the patch in account-mfe which fixes the above issue

Solves https://github.com/overhangio/tutor/issues/1111