### PR TITLE
node 20 upgrade

### DIFF
--- a/changelog.d/20241010_090821_arbrandes_node_20_upgrade.md
+++ b/changelog.d/20241010_090821_arbrandes_node_20_upgrade.md
@@ -1,0 +1,2 @@
+
+- [Feature] Upgrade to Node 20. (by @arbrandes)

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # https://hub.docker.com/_/node/tags
-FROM docker.io/node:18.19.0-bullseye-slim AS base
+FROM docker.io/node:20.18.0-bullseye-slim AS base
 
 RUN apt update \
   && apt install -y git \


### PR DESCRIPTION
As per https://github.com/openedx/public-engineering/issues/267, all Tutor-supported MFEs now work on Node 20, so we're good to switch to the Node 20 image.

Fixes #198 