### PR TITLE
fix: add script to install node_modules in mounted mfes

### DIFF
--- a/tutormfe/patches/dev-docker-compose-jobs-services
+++ b/tutormfe/patches/dev-docker-compose-jobs-services
@@ -1,0 +1,11 @@
+{%- for app_name, app in iter_mfes() %}
+{%- set mounts = iter_mounts(MOUNTS, app_name)|list %}
+{%- if mounts %}
+{{ app_name }}-job: 
+    image: "{{ MFE_DOCKER_IMAGE_DEV_PREFIX }}-{{ app_name }}-dev:{{ MFE_VERSION }}"
+    volumes:
+        {%- for mount in mounts %}
+        - {{ mount }}
+        {%- endfor %}
+{%- endif %}
+{%- endfor %}

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import os
+import re
 import typing as t
 from glob import glob
 
@@ -304,3 +305,27 @@ def _check_mfe_host(config: Config) -> None:
             f'Warning: MFE_HOST="{mfe_host}" is not a subdomain of LMS_HOST="{lms_host}". '
             "This configuration is not typically recommended and may lead to unexpected behavior."
         )
+    
+
+@tutor_hooks.Actions.CONFIG_LOADED.add()
+def _run_jobs_in_mounted_mfes(config: Config) -> None:
+    mounts = get_typed(config, "MOUNTS", list, [])
+
+    pattern = re.compile(r'frontend-app-(\w+)')
+    mounted_mfes = [match.group(1) for mount in mounts if (match := pattern.search(mount))]
+
+    mfe_task_file = os.path.join(
+        str(
+            importlib_resources.files("tutormfe")
+            / "templates"
+            / "mfe"
+            / "tasks"
+            / "mfe"
+            / "npm-install.sh"
+        )
+    )
+
+    for mounted_mfe in mounted_mfes:
+        with tutor_hooks.Contexts.app("mfe").enter():
+            with open(mfe_task_file, encoding='utf-8') as fi:
+                tutor_hooks.Filters.CLI_DO_INIT_TASKS.add_item((mounted_mfe , fi.read()))

--- a/tutormfe/templates/mfe/tasks/mfe/npm-install.sh
+++ b/tutormfe/templates/mfe/tasks/mfe/npm-install.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Paths for the fingerprint and package-lock.json
+FINGERPRINT_FILE="node_modules/.fingerprint"
+PACKAGE_LOCK="package-lock.json"
+
+# Function to generate the SHA1 hash of the package-lock.json file
+generate_fingerprint() {
+  sha1sum "$PACKAGE_LOCK" | awk '{print $1}'
+}
+
+# Check if node_modules exists and fingerprint is valid
+if [ ! -d "node_modules" ]; then
+  echo "⚠️  node_modules not found! Installing dependencies..."
+  npm clean-install
+
+elif [ ! -f "$FINGERPRINT_FILE" ]; then
+  echo "⚠️  Fingerprint file not found! Re-installing dependencies..."
+  npm clean-install
+
+else
+  CURRENT_FINGERPRINT=$(generate_fingerprint)
+  STORED_FINGERPRINT=$(cat "$FINGERPRINT_FILE")
+
+  if [ "$CURRENT_FINGERPRINT" != "$STORED_FINGERPRINT" ]; then
+    echo "⚠️  package-lock.json changed! Re-installing dependencies..."
+    npm clean-install
+  else
+    echo "✅ Dependencies are up to date."
+    exit 0
+  fi
+fi
+
+# Store the new fingerprint after installation
+generate_fingerprint > "$FINGERPRINT_FILE"
+echo "✅ Dependencies installed and fingerprint updated."


### PR DESCRIPTION
#### WIP

These code changes introduce improvements to the Tutor MFE (Micro-Frontend) plugin by adding automation and efficiency for managing and running tasks in environments where MFEs are mounted. When MFEs are mounted, it will run `npm clean-install` as part of the run `tutor dev launch`. The "mfe" init task `npm-install.sh` is taking care of installing the node_modules, as it is done in the [LMS](https://github.com/overhangio/tutor/blob/master/tutor/templates/jobs/init/mounted-directories.sh)

Test Cases:
- [x] It will run the `npm-install` script when MFEs are **implicitly** and **expicitly** mounted using the Tutor format: `tutor mounts add $(pwd)/frontend-app-*` & `tutor mounts add [mfe-name]:$(pwd)/frontend-app-*:/openedx/app`.
- [x] The job should run for all mounted MFEs
- [ ] The job will run only in `tutor dev`, not `tutor local`, as MFEs mount only in `tutor dev` environment.
- [x] If no `node_modules` are present, it should install `node_modules`.
- [x] If the `node_modules` directory exists but is empty or outdated, it should install `node_modules`.
- [x] If the `package-lock.json` file changes slightly, it should trigger reinstallation of `node_modules`.
- [x] If `node_modules` are installed and then reinstallation is attempted without changes to `package-lock.json`, it should **not** reinstall `node_modules`.

Closes #218 