### PR TITLE
feat: support frontend plugins via env.config.jsx

### DIFF
--- a/20241111_172451_arbrandes_frontend_plugin_support.md
+++ b/20241111_172451_arbrandes_frontend_plugin_support.md
@@ -1,0 +1,1 @@
+- [Improvement] Adds support for frontend plugin slot configuration via env.config.jsx. (by @arbrandes)

--- a/tutormfe/hooks.py
+++ b/tutormfe/hooks.py
@@ -13,3 +13,5 @@ from tutor.core.hooks import Filter
 MFE_ATTRS_TYPE = t.Dict[t.Literal["repository", "port", "version"], t.Union["str", int]]
 
 MFE_APPS: Filter[dict[str, MFE_ATTRS_TYPE], []] = Filter()
+
+MFE_SLOTS: Filter[list[str], []] = Filter()

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -62,6 +62,7 @@ ENV PUBLIC_PATH='/{{ app_name }}/'
 # So we point to a relative url that will be a proxy for the LMS.
 ENV MFE_CONFIG_API_URL=/api/mfe_config/v1
 ARG ENABLE_NEW_RELIC=false
+COPY env.config.jsx /openedx/app
 {{ patch("mfe-dockerfile-pre-npm-build") }}
 {{ patch("mfe-dockerfile-pre-npm-build-{}".format(app_name)) }}
 

--- a/tutormfe/templates/mfe/build/mfe/env.config.jsx
+++ b/tutormfe/templates/mfe/build/mfe/env.config.jsx
@@ -1,0 +1,53 @@
+{{- patch("mfe-env-config-static-imports") }}
+{{- patch("mfe-env-config-head") }}
+
+async function getConfig () {
+  let config = {};
+
+  try {
+    /* We can't assume FPF exists, as it's not declared as a dependency in all
+     * MFEs, so we import it dynamically. In addition, for dynamic imports to
+     * work with Webpack all of the code that actually uses the imported module
+     * needs to be inside the `try{}` block.
+     */
+    const { DIRECT_PLUGIN, PLUGIN_OPERATIONS } = await import('@openedx/frontend-plugin-framework');
+    {{- patch("mfe-env-config-dynamic-imports") }}
+
+    config = {
+      pluginSlots: {
+        {%- for slot_name in iter_slots() %}
+        {%- if patch("mfe-env-config-plugin-{}".format(slot_name)) %}
+        {{ slot_name }}: {
+          keepDefault: true,
+          plugins: [
+            {{- patch("mfe-env-config-plugin-{}".format(slot_name)) }}
+          ]
+        },
+        {%- endif %}
+        {%- endfor %}
+      }
+    };
+
+    {%- for app_name, app in iter_mfes() %}
+    if (process.env.npm_package_name == '@edx/frontend-app-{{ app_name }}') {
+      {%- if patch("mfe-env-config-dynamic-imports-{}".format(app_name)) %}
+      {{- patch("mfe-env-config-dynamic-imports-{}".format(app_name)) }}
+      {%- endif %}
+
+      {%- for slot_name in iter_slots() %}
+      {%- if patch("mfe-env-config-plugin-{}-{}".format(app_name, slot_name)) %}
+      config.pluginSlots.{{ slot_name }}.plugins.push(
+        {{- patch("mfe-env-config-plugin-{}-{}".format(app_name, slot_name)) }}
+      );
+      {%- endif %}
+      {%- endfor %}
+    }
+    {%- endfor %}
+
+    {{- patch("mfe-env-config-tail") }}
+  } catch { }
+
+  return config;
+}
+
+export default getConfig;


### PR DESCRIPTION
This provides a mechanism to configure frontend plugins using patches to a base `env.config.jsx`, in such a way that multiple plugins can take advantage of the file (including for purposes beyond frontend plugins) without clobbering each other.

This is an alternate approach to #233.
