### PR TITLE
fix: render mfe-ports for  unmounted mfes when these exist

### DIFF
--- a/changelog.d/20250226_134324_ahmed.khalid_mfe_ports_bug.md
+++ b/changelog.d/20250226_134324_ahmed.khalid_mfe_ports_bug.md
@@ -1,1 +1,1 @@
-- [Bugfix] Fixed syntax error in Docker configuration when all MFEs are mounted by ensuring the `ports:` section is only included if unmounted MFEs exist. (by @ahmed-arb and hinakhadim)  
+- [Bugfix] Fixed syntax error in Docker configuration when all MFEs are mounted by ensuring the `ports:` section is only included if unmounted MFEs exist. (by @ahmed-arb and @hinakhadim)  

--- a/changelog.d/20250226_134324_ahmed.khalid_mfe_ports_bug.md
+++ b/changelog.d/20250226_134324_ahmed.khalid_mfe_ports_bug.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fixed syntax error in Docker configuration when all MFEs are mounted by ensuring the `ports:` section is only included if unmounted MFEs exist. (by @ahmed-arb and hinakhadim)  

--- a/tutormfe/patches/local-docker-compose-dev-services
+++ b/tutormfe/patches/local-docker-compose-dev-services
@@ -1,10 +1,17 @@
+{%- set unmounted_mfes = [] %}
+{%- for app_name, app in iter_mfes() %}
+   {%- if not iter_mounts(MOUNTS, app_name)|list %}
+       {%- set _ = unmounted_mfes.append((app_name, app)) %}
+   {%- endif %}
+{%- endfor %}
+{% if unmounted_mfes|length > 0 %}
 mfe:
-    ports:
-        {%- for app_name, app in iter_mfes() %}
-        {%- if not iter_mounts(MOUNTS, app_name)|list %}
-        - {{ app["port"] }}:8002 # {{ app_name }}
-        {%- endif %}
-        {%- endfor %}
+   ports:
+       {%- for app_name, app in unmounted_mfes %}
+       - {{ app["port"] }}:8002 # {{ app_name }}
+       {%- endfor %}
+{% endif %}
+
 
 {%- for app_name, app in iter_mfes() %}
 {%- set mounts = iter_mounts(MOUNTS, app_name)|list %}

--- a/tutormfe/patches/local-docker-compose-dev-services
+++ b/tutormfe/patches/local-docker-compose-dev-services
@@ -1,8 +1,6 @@
-{%- set unmounted_mfes = [] %}
+{%- set mfe_data = MFEMountData(MOUNTS) %}
 
-{%- for app_name, app in iter_mfes() %}
-{%- set mounts = iter_mounts(MOUNTS, app_name)|list %}
-{%- if mounts %}
+{%- for app_name, app, mounts in mfe_data.mounted %}
 {{ app_name }}: # Work on this MFE for development
     image: "{{ MFE_DOCKER_IMAGE_DEV_PREFIX }}-{{ app_name }}-dev:{{ MFE_VERSION }}"
     ports:
@@ -19,16 +17,13 @@
         - lms
     environment:
         - "PORT={{ app['port'] }}"
-{%- else %}
-{%- set unmounted_mfes = unmounted_mfes.append((app_name, app)) %}
-{%- endif %}
 {%- endfor %}
 
 
-{% if unmounted_mfes|length > 0 %}
+{% if mfe_data.unmounted|length > 0 %}
 mfe:
    ports:
-       {%- for app_name, app in unmounted_mfes %}
+       {%- for app_name, app in mfe_data.unmounted %}
        - {{ app["port"] }}:8002 # {{ app_name }}
        {%- endfor %}
 {% endif %}

--- a/tutormfe/patches/local-docker-compose-dev-services
+++ b/tutormfe/patches/local-docker-compose-dev-services
@@ -1,17 +1,4 @@
 {%- set unmounted_mfes = [] %}
-{%- for app_name, app in iter_mfes() %}
-   {%- if not iter_mounts(MOUNTS, app_name)|list %}
-       {%- set _ = unmounted_mfes.append((app_name, app)) %}
-   {%- endif %}
-{%- endfor %}
-{% if unmounted_mfes|length > 0 %}
-mfe:
-   ports:
-       {%- for app_name, app in unmounted_mfes %}
-       - {{ app["port"] }}:8002 # {{ app_name }}
-       {%- endfor %}
-{% endif %}
-
 
 {%- for app_name, app in iter_mfes() %}
 {%- set mounts = iter_mounts(MOUNTS, app_name)|list %}
@@ -32,5 +19,16 @@ mfe:
         - lms
     environment:
         - "PORT={{ app['port'] }}"
+{%- else %}
+{%- set unmounted_mfes = unmounted_mfes.append((app_name, app)) %}
 {%- endif %}
 {%- endfor %}
+
+
+{% if unmounted_mfes|length > 0 %}
+mfe:
+   ports:
+       {%- for app_name, app in unmounted_mfes %}
+       - {{ app["port"] }}:8002 # {{ app_name }}
+       {%- endfor %}
+{% endif %}


### PR DESCRIPTION
### Description
The issue occurs when all MFEs (Micro Frontends) are mounted, and the `ports` section in the Docker configuration is left empty, leading to a syntax error in the generated Dockerfile. Specifically, the `ports:` line becomes invalid as another key follows it (`auth:`) without any content. In the `tutor dev` context, the issue occurs because developers mount MFEs for testing purposes. It won't reproduce for `tutor local`.

```
...

mfe:
    ports:
auth:
   ....
```

### How to Reproduce
- Clone all MFEs (`authn, account, communications, course-authoring, discussions, gradebook, learner-dashboard, learning, ora-grading, profile`)
- Run `tutor mounts add $(pwd)/frontend-app-*` where `*` represents all MFEs name one by one
- `tutor config save`
- `tutor dev start` OR directly check the `mfe-ports` section in `tutor-env/env/dev/docker-compose.yml` 

### What this PR does
This PR resolves the issue by implementing logic to first check if any unmounted MFEs exist. If unmounted MFEs are found, their corresponding ports are rendered in the ports: section. This ensures that the Docker configuration is generated correctly and avoids errors caused by leaving the `ports:` section empty.


### TestCases:
- [x] If any unmounted MFE exists, its corresponding port should be rendered under the `mfe: ports:` section.
```
...

mfe:
    ports:
        - 1997:8002 # account
        - 1984:8002 # communications

authn:
    image: ...
...           
```
- [x] If no unmounted MFEs exist, the `mfe: ports:` section should be excluded entirely from the generated output.
```
...
#There should be no section of mfe->ports

authn:
     image: ....
...          
```

Closes https://github.com/overhangio/tutor-mfe/issues/242