### PR TITLE
chore: remove unnecessary settings and waffle flags for account and profile MFEs

### DIFF
--- a/changelog.d/20250324_232034_danyal.faheem_remove_site_configuration_script.md
+++ b/changelog.d/20250324_232034_danyal.faheem_remove_site_configuration_script.md
@@ -1,0 +1,1 @@
+- [Improvement] Remove unnecessary site-configuration settings and waffle flags for the account and profile MFEs. (by @Danyal-Faheem)

--- a/tutormfe/templates/mfe/tasks/lms/init
+++ b/tutormfe/templates/mfe/tasks/lms/init
@@ -10,11 +10,7 @@ grep account.redirect_to_microfrontend /tmp/lms_waffle_flags.txt || ./manage.py 
 
 {% if is_mfe_enabled("profile") %}
 grep learner_profile.redirect_to_microfrontend /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone learner_profile.redirect_to_microfrontend
-site-configuration set --domain={{ LMS_HOST }} ENABLE_PROFILE_MICROFRONTEND true
-site-configuration set --domain={{ LMS_HOST }}:8000 ENABLE_PROFILE_MICROFRONTEND true
 {% else %}
-site-configuration unset --domain={{ LMS_HOST }} ENABLE_PROFILE_MICROFRONTEND
-site-configuration unset --domain={{ LMS_HOST }}:8000 ENABLE_PROFILE_MICROFRONTEND
 ./manage.py lms waffle_delete --flags learner_profile.redirect_to_microfrontend
 {% endif %}
 

--- a/tutormfe/templates/mfe/tasks/lms/init
+++ b/tutormfe/templates/mfe/tasks/lms/init
@@ -2,17 +2,9 @@
 ./manage.py lms waffle_flag --list > /tmp/lms_waffle_flags.txt
 
 {% if is_mfe_enabled("account") %}
-grep account.redirect_to_microfrontend /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone account.redirect_to_microfrontend
 ./manage.py lms populate_retirement_states
-{% else %}
-./manage.py lms waffle_delete --flags account.redirect_to_microfrontend
 {% endif %}
 
-{% if is_mfe_enabled("profile") %}
-grep learner_profile.redirect_to_microfrontend /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone learner_profile.redirect_to_microfrontend
-{% else %}
-./manage.py lms waffle_delete --flags learner_profile.redirect_to_microfrontend
-{% endif %}
 
 {% if is_mfe_enabled("learner-dashboard") %}
 grep learner_home_mfe.enabled /tmp/lms_waffle_flags.txt || ./manage.py lms waffle_flag --create --everyone learner_home_mfe.enabled


### PR DESCRIPTION
Fixes part of https://github.com/overhangio/tutor/issues/1207.

As the site-configuration script is planned for deprecation in tutor-core, we look to remove or update its usage with a suitable replacement.

However, as of https://github.com/openedx/edx-platform/pull/36219, we do not require the site-configuration entries for the profile MFE anymore as the MFE is the default frontend going forward.

Similarly, the `redirect_to_microfrontend` flags are also not required anymore for the account and profile MFE as they are now the default frontends going forward.