### PR TITLE
[DRAFT] feat! replace webpack by rsbuild for faster build

### DIFF
--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -32,6 +32,7 @@ config = {
 }
 
 CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
+    # TODO restore vanilla repositories
     "authn": {
         "repository": "https://github.com/openedx/frontend-app-authn.git",
         "port": 1999,
@@ -45,7 +46,9 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
         "port": 1997,
     },
     "communications": {
-        "repository": "https://github.com/openedx/frontend-app-communications.git",
+        "repository": "https://github.com/regisb/frontend-app-communications.git",
+        "version": "regisb/rsbuild",
+        # "repository": "https://github.com/openedx/frontend-app-communications.git",
         "port": 1984,
     },
     "discussions": {
@@ -53,11 +56,15 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
         "port": 2002,
     },
     "gradebook": {
-        "repository": "https://github.com/openedx/frontend-app-gradebook.git",
+        "repository": "https://github.com/regisb/frontend-app-gradebook.git",
+        "version": "regisb/rsbuild",
+        # "repository": "https://github.com/openedx/frontend-app-gradebook.git",
         "port": 1994,
     },
     "learner-dashboard": {
-        "repository": "https://github.com/openedx/frontend-app-learner-dashboard.git",
+        "repository": "https://github.com/regisb/frontend-app-learner-dashboard.git",
+        "version": "regisb/rsbuild",
+        # "repository": "https://github.com/openedx/frontend-app-learner-dashboard.git",
         "port": 1996,
     },
     "learning": {
@@ -65,7 +72,9 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
         "port": 2000,
     },
     "ora-grading": {
-        "repository": "https://github.com/openedx/frontend-app-ora-grading.git",
+        "repository": "https://github.com/regisb/frontend-app-ora-grading.git",
+        "version": "regisb/rsbuild",
+        # "repository": "https://github.com/openedx/frontend-app-ora-grading.git",
         "port": 1993,
     },
     "profile": {

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update \
     # required for gifsicle, mozjpeg, and optipng (on arm)
     autoconf libtool pkg-config zlib1g-dev \
     # required for node-sass (on arm)
-    python g++ \
+    python3 g++ \
     # required for image-webpack-loader (on arm)
     libpng-dev \
     # required for building node-canvas (on arm, for authoring)

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -17,8 +17,14 @@ RUN apt update \
     libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
 RUN mkdir -p /openedx/app /openedx/env
+
+# Install shared dependencies in /openedx/node_modules
+WORKDIR /openedx/
+RUN npm install @rsbuild/core @rsbuild/plugin-react @rsbuild/plugin-svgr @rsbuild/plugin-sass
+
+# Install apps in /openedx/app
 WORKDIR /openedx/app
-ENV PATH=/openedx/app/node_modules/.bin:${PATH}
+ENV PATH=/openedx/app/node_modules/.bin:/openedx/node_modules/.bin:${PATH}
 
 {{ patch("mfe-dockerfile-base") }}
 
@@ -77,7 +83,9 @@ CMD ["/bin/bash", "-c", "npm run start --- --config ./webpack.dev-tutor.config.j
 ######## {{ app_name }} (production)
 FROM {{ app_name }}-common AS {{ app_name }}-prod
 ENV NODE_ENV=production
-RUN npm run build
+COPY rsbuild.config.ts /openedx/app/rsbuild.config.ts
+{# Locked cache will prevent concurrent builds of MFE apps, to spare CPU usage #}
+RUN --mount=type=cache,target=/openedx/app/node_modules/.cache,sharing=locked rsbuild build
 {{ patch("mfe-dockerfile-post-npm-build") }}
 {{ patch("mfe-dockerfile-post-npm-build-{}".format(app_name)) }}
 {% endfor %}

--- a/tutormfe/templates/mfe/build/mfe/rsbuild.config.ts
+++ b/tutormfe/templates/mfe/build/mfe/rsbuild.config.ts
@@ -31,6 +31,7 @@ const appName = parsedEnv.APP_ID || path.basename(currentDir).replace('frontend-
 const publicPath = parsedEnv.PUBLIC_PATH || '/' + appName + '/';
 const dev = parsedEnv.NODE_ENV === 'development';
 const prod = !dev;
+const isArm64 = (process.arch === 'arm64');
 parsedEnv.APP_ID = appName;
 parsedEnv.PUBLIC_PATH = publicPath;
 parsedEnv.MFE_CONFIG_API_URL = prod ? '/api/mfe_config/v1' : 'http://local.openedx.io:8000/api/mfe_config/v1';
@@ -65,9 +66,11 @@ const config = defineConfig({
         }
     },
     performance: {
-        // We enable caching everywhere, even if it's unnecessary in some places. The
-        // negative impact on performance should be minor.
-        buildCache: true,
+        // We enable caching everywhere except on amd64, even if it's unnecessary in
+        // some places. The negative impact on performance should be minor.
+        // The reason we disable it on arm64 is that build is failing on this platform
+        // https://github.com/web-infra-dev/rspack/issues/10118
+        buildCache: isArm64 ? false : true,
     },
     server: {
         base: publicPath,

--- a/tutormfe/templates/mfe/build/mfe/rsbuild.config.ts
+++ b/tutormfe/templates/mfe/build/mfe/rsbuild.config.ts
@@ -1,0 +1,157 @@
+// Install dependencies:
+//
+//     npm install --no-save @rsbuild/core @rsbuild/plugin-react @rsbuild/plugin-svgr @rsbuild/plugin-sass @rsdoctor/rspack-plugin
+//
+// Build with:
+//
+//     rsbuild build
+//
+// Develop with:
+//
+//     rsbuild
+//
+// Troubleshoot with:
+//
+//     RSDOCTOR=true rsbuild build
+
+import path from 'path';
+import fs from 'fs';
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+import { pluginSvgr } from '@rsbuild/plugin-svgr';
+import { pluginSass } from '@rsbuild/plugin-sass';
+import { loadEnv } from '@rsbuild/core';
+
+// Load environment variables
+// https://rsbuild.dev/api/javascript-api/core#loadenv
+const currentDir = process.cwd();
+const parsedEnv = loadEnv({ mode: 'production' }).parsed;
+const parsedEnvDev = loadEnv({ mode: 'development' }).parsed;
+const appName = parsedEnv.APP_ID || path.basename(currentDir).replace('frontend-app-', '');
+const publicPath = parsedEnv.PUBLIC_PATH || '/' + appName + '/';
+const dev = parsedEnv.NODE_ENV === 'development';
+const prod = !dev;
+parsedEnv.APP_ID = appName;
+parsedEnv.PUBLIC_PATH = publicPath;
+parsedEnv.MFE_CONFIG_API_URL = prod ? '/api/mfe_config/v1' : 'http://local.openedx.io:8000/api/mfe_config/v1';
+
+// Load env.config.(js|jsx)
+var envConfigPath = '';
+try {
+    await import('@openedx/frontend-plugin-framework');
+    if (fs.existsSync(path.resolve(currentDir, './env.config.jsx'))) {
+        envConfigPath = path.resolve(currentDir, './env.config.jsx');
+    } else if (fs.existsSync(path.resolve(currentDir, './env.config.js'))) {
+        envConfigPath = path.resolve(currentDir, './env.config.js');
+    }
+} catch {
+    // FPF is not available, we don't try to load env.config.js
+}
+
+const config = defineConfig({
+    html: {
+        template: './public/index.html',
+    },
+    output: {
+        // Flat directory
+        // TODO do we want a flat directory?
+        // distPath: {
+        //     js: '',
+        //     css: '',
+        // },
+        sourceMap: {
+            js: prod ? 'source-map' : 'eval',
+            css: true,
+        }
+    },
+    performance: {
+        // We enable caching everywhere, even if it's unnecessary in some places. The
+        // negative impact on performance should be minor.
+        buildCache: true,
+    },
+    server: {
+        base: publicPath,
+        // Redirect all get requests to index.html
+        // https://rsbuild.dev/config/server/history-api-fallback
+        historyApiFallback: true,
+        port: parseInt(parsedEnvDev.PORT),
+    },
+    source: {
+        define: {
+            // This is explicitly recommended against, but this is how MFEs are built
+            // https://rsbuild.dev/guide/advanced/env-vars#processenv-replacement
+            'process.env': JSON.stringify(parsedEnv),
+        },
+        transformImport: [
+            // https://rsbuild.dev/config/source/transform-import#import-lodash-on-demand
+            {
+                libraryName: 'lodash',
+                customName: 'lodash/{' + '{ member }' + '}',
+            },
+            {
+                libraryName: '@fortawesome/free-brands-svg-icons',
+                customName: '@fortawesome/free-brands-svg-icons/{' + '{ member }' + '}',
+                transformToDefaultImport: false,
+            },
+            {
+                libraryName: '@fortawesome/free-regular-svg-icons',
+                customName: '@fortawesome/free-regular-svg-icons/{' + '{ member }' + '}',
+                transformToDefaultImport: false,
+            },
+            {
+                libraryName: '@fortawesome/free-solid-svg-icons',
+                customName: '@fortawesome/free-solid-svg-icons/{' + '{ member }' + '}',
+                transformToDefaultImport: false,
+            },
+        ],
+    },
+    plugins: [
+        // https://rsbuild.dev/plugins/list/plugin-react
+        pluginReact(),
+        // https://rsbuild.dev/plugins/list/plugin-svgr#mixedimport
+        pluginSvgr({
+            mixedImport: true,
+            svgrOptions: {
+                exportType: 'named',
+            },
+        }),
+        // https://rsbuild.dev/plugins/list/plugin-sass
+        pluginSass({
+            sassLoaderOptions: {
+                sassOptions: {
+                    silenceDeprecations: ['abs-percent', 'color-functions', 'import', 'mixed-decls', 'global-builtin', 'legacy-js-api'],
+                },
+            },
+        }),
+    ],
+    resolve: {
+        alias: {
+            'env.config': envConfigPath || false,
+        }
+    }
+});
+
+///////////////////////
+// MFE-specific changes
+///////////////////////
+
+// This is horrible but we don't have a choice
+if (appName == 'authoring') {
+    config.resolve!.alias!['CourseAuthoring'] = path.resolve(currentDir, 'src/');
+} else if (appName == 'communications') {
+    // config.resolve!.alias![''] = './src';
+    config.resolve!.alias!['@src'] = path.resolve(currentDir, 'src');
+} else if (appName == 'gradebook') {
+    // config.resolve!.alias![''] = './src';
+    config.resolve!.alias!['@src'] = path.resolve(currentDir, 'src');
+} else if (appName == 'learner-dashboard') {
+    // config.resolve!.alias![''] = './src';
+    config.resolve!.alias!['@src'] = path.resolve(currentDir, 'src');
+} else if (appName === 'learning') {
+    config.resolve!.alias!['@src'] = path.resolve(currentDir, 'src');
+} else if (appName == 'ora-grading') {
+    // config.resolve!.alias![''] = './src';
+    config.resolve!.alias!['@src'] = path.resolve(currentDir, 'src');
+}
+
+export default config;


### PR DESCRIPTION
This is the result of a long investigation to accelerate the building of MFE apps in Open edX. Many of the intermediate results can be found in this issue: https://github.com/openedx/wg-frontend/issues/184

The tl;dr is that building MFEs takes a very long time, and that's because of Webpack. In this PR, we replace Webpack by [rsbuild](https://rsbuild.dev/), resulting in a considerable performance improvement.

This PR is dependent on the following upstream PRs:

- https://github.com/openedx/frontend-app-communications/pull/223
- https://github.com/openedx/frontend-app-gradebook/pull/446
- https://github.com/openedx/frontend-app-ora-grading/pull/408
- https://github.com/openedx/frontend-app-learner-dashboard/pull/598

## Open questions

- **Does this still support env.config.jsx customisations?** I think it should, but I haven't checked.
- **Does this build Paragon?** I have no idea. Probably not. To this day I still don't know what's Paragon.

## TODO

Things we need to address before (if?) we merge:

- Remove references to regisb/rsbuild in plugin.py
- Pin rsbuild dependencies in Dockerfile
- Add changelog entry

## Benchmarks

### Configuration

These benchmarks are performed on my personal computer: a Intel(R) Core(TM) i5-4670K CPU @ 3.40GHz with 4 processors and 20 GB RAM. My custom Docker builder runs with `max-parallelism = 4`, as per [these instructions](https://docs.tutor.edly.io/troubleshooting.html#high-resource-consumption-by-docker-on-tutor-images-build):

```
$ docker buildx ls
NAME/NODE        DRIVER/ENDPOINT                           STATUS    BUILDKIT   PLATFORMS
max4cpu*         docker-container                                               
 \_ max4cpu0      \_ unix:///var/run/docker.sock           running   v0.13.1    linux/amd64 (+3), linux/386
```

All plugins are disabled, except for "mfe" and "forum", and there is no bind-mount:

```
tutor plugins disable all
tutor plugins enable mfe forum
tutor mounts list
```

The "mfe" image is built from scratch on the "main" branch; then, we re-build the image by clearing the cache for the "*-prod" build steps, which are the ones that run `npm run build`:

```
# Update environment
tutor config save
# Fill cache
tutor images build mfe
# Build without cache
time tutor images build --docker-arg=--no-cache-filter=account-prod,authn-prod,authoring-prod,communications-prod,discussions-prod,ecommerce-prod,gradebook-prod,learner-dashboard-prod,learning-prod,ora-grading-prod,payment-prod,profile-prod mfe
```

The changes in this PR are tested by checking out this branch:

```
cd <path to>/tutor-mfe
git checkout regisb/rsbuild
```

Then run the commands above.

We list the benchmarks by date, because we expect these figures to change as we iterate on this PR.

### Reference times

#### Reference 1: total build time

On the main branch, the total elapsed ("real") time of that last step is **468 s** (7 min 48 s). This will serve as a point of reference for all benchmarks.

#### Reference 2: no parallelism build of the learning MFE

Another interesting point of reference is the time that is needed to build the learning MFE, without parallelism -- that is, without concurrent builds of other MFEs. This is a figure that can be obtained by running:

```
time tutor images build --docker-arg=--no-cache-filter=learning-prod --target=learning-prod mfe
```

And then checking the time to build the MFE in the Docker logs: 

```
 => [learning-prod 1/1] RUN npm run build                                119.5s
```

Here, the reference time is **119.5s**.

### Single-thread build of the learning app

### 2025/04/10 Locked cache

We added the following locked cache in the build step:

```
RUN --mount=type=cache,target=/openedx/app/node_modules/.cache,sharing=locked rsbuild build
```

This causes all builds to run sequentially, and not in parallel. The good thing with this change is that it allows us to no longer customise our Docker builder with `max-parallelism=x`. The only downside is that there might be a drop in performance; but in practice, we don't really observe a noticeable one.

- Ref 1: 96s
- Ref 2: 9.2s (practically unchanged)

### 2025/04/09 Initial results

- **Ref 1:** **85-105s** (4.46-5.5x improvement)
- **Ref 2:** **7.1s** (14.8x improvement)

All MFEs build under 23s, despite the fact that there are 4 builds in parallel:

```
 => [communications-prod 2/2] RUN rsbuild build                                       21.7s
 => [learner-dashboard-prod 2/2] RUN rsbuild build                                    23.0s
 => [learning-prod 2/2] RUN rsbuild build                                             22.7s
 => [discussions-prod 2/2] RUN rsbuild build                                          22.6s
 => [gradebook-prod 2/2] RUN rsbuild build                                            24.1s
 => [ora-grading-prod 2/2] RUN rsbuild build                                          22.6s
 => [account-prod 2/2] RUN rsbuild build                                              22.7s
 => [authn-prod 2/2] RUN rsbuild build                                                22.7s
 => [profile-prod 2/2] RUN rsbuild build                                              18.6s
 => [authoring-prod 2/2] RUN rsbuild build                                            18.5s
```
