### PR TITLE
chore: add console error logging in env.config.jsx template

### DIFF
--- a/tutormfe/templates/mfe/build/mfe/env.config.jsx
+++ b/tutormfe/templates/mfe/build/mfe/env.config.jsx
@@ -43,7 +43,7 @@ async function setConfig () {
     {%- endfor %}
 
     {{- patch("mfe-env-config-runtime-final") }}
-  } catch (error) { console.error("env.config.jsx failed to apply.";}
+  } catch (err) { console.error("env.config.jsx failed to apply.", err);}
 
   return config;
 }

--- a/tutormfe/templates/mfe/build/mfe/env.config.jsx
+++ b/tutormfe/templates/mfe/build/mfe/env.config.jsx
@@ -43,7 +43,7 @@ async function setConfig () {
     {%- endfor %}
 
     {{- patch("mfe-env-config-runtime-final") }}
-  } catch { }
+  } catch (error) { console.error("env.config.jsx failed to apply.";}
 
   return config;
 }

--- a/tutormfe/templates/mfe/build/mfe/env.config.jsx
+++ b/tutormfe/templates/mfe/build/mfe/env.config.jsx
@@ -43,7 +43,7 @@ async function setConfig () {
     {%- endfor %}
 
     {{- patch("mfe-env-config-runtime-final") }}
-  } catch (err) { console.error("env.config.jsx failed to apply.", err);}
+  } catch (err) { console.error("env.config.jsx failed to apply: ", err);}
 
   return config;
 }


### PR DESCRIPTION
Edly recently faced an issue with Teak sandbox in which env.config.jsx did not apply when both Indigo and Aspects plugins were enabled. Upon debugging, it was found that there was an issue in env.config.jsx related patches in Indigo which caused this. However, it was not apparent at first that this was the issue and it required debugging and re-building images to pinpoint the issue. While we are fixing the Indigo issue in https://github.com/overhangio/tutor-indigo/pull/148, we are adding a small change in tutor-mfe to log the error in env.config.jsx if config fails to apply for any reason. This will make future debugging easier.