### PR TITLE
feat: add volume patches to mfe service and k8s

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -762,6 +762,20 @@ Add any configurations for the mfe-caddyfile.
 
 File changed: ``tutormfe/templates/mfe/apps/mfe/Caddyfile``
 
+mfe-volumes
+~~~~~~~~~~~
+
+Add volumes to the mfe service in local Docker Compose deployment.
+
+File changed: ``local/docker-compose.yml``
+
+mfe-k8s-volumes
+~~~~~~~~~~~~~~~
+
+Add volumes to the mfe deployment in Kubernetes.
+
+File changed: ``k8s/deployments.yml``
+
 
 Troubleshooting
 ---------------

--- a/tutormfe/patches/k8s-deployments
+++ b/tutormfe/patches/k8s-deployments
@@ -26,3 +26,4 @@ spec:
         - name: config
           configMap:
             name: mfe-caddy-config
+        {{ patch("mfe-k8s-volumes") | indent(8) }}

--- a/tutormfe/patches/local-docker-compose-dev-services
+++ b/tutormfe/patches/local-docker-compose-dev-services
@@ -20,9 +20,10 @@
 {%- endfor %}
 
 
-{% if mfe_data.unmounted|length > 0 %}
+{% if mfe_data.unmounted|length > 0 or PARAGON_VERSION is defined %}
 mfe:
    ports:
+       - 8002:8002
        {%- for app_name, app in mfe_data.unmounted %}
        - {{ app["port"] }}:8002 # {{ app_name }}
        {%- endfor %}

--- a/tutormfe/patches/local-docker-compose-services
+++ b/tutormfe/patches/local-docker-compose-services
@@ -4,5 +4,6 @@ mfe:
     restart: unless-stopped
     volumes:
         - ../plugins/mfe/apps/mfe/Caddyfile:/etc/caddy/Caddyfile:ro
+        {{ patch("mfe-volumes") | indent(8) }}
     depends_on:
         - lms


### PR DESCRIPTION
## Description

This pull request enhances the `tutor-mfe` plugin by adding the necessary hooks to allow other plugins, such as `tutor-paragon`, to serve static files using the `mfe` Caddy service. This is achieved by introducing new volume patches for both local and Kubernetes deployments and updating the service logic for development environments.

> [!NOTE]
> For further context, please refer to the following discussion: [https://github.com/openedx/openedx-tutor-plugins/pull/38](https://github.com/openedx/openedx-tutor-plugins/pull/38)


### Key Changes

* **Volume Support for MFE Service**:
    * A new `mfe-volumes` patch has been added to the local Docker Compose service to allow mounting additional volumes.
    * A corresponding `mfe-k8s-volumes` patch has been added to the Kubernetes deployment configuration.

* **Development Environment Enhancements**:
    To support hosting external files even when no MFEs are running in production mode, the `dev` service logic has been updated:
    1.  A default port mapping (`8002:8002`) is now included to ensure the `mfe` Caddy container is always accessible from the host.
    2.  The conditional check for starting the `mfe` service now evaluates `or PARAGON_VERSION is defined`. This handles the edge case where a user mounts all available MFEs for development (`mfe_data.unmounted` is empty), but still needs the `mfe` service to host custom files like those from Paragon.
* **Documentation**:
     The `README.rst` has been updated to include documentation for the new `mfe-volumes` and `mfe-k8s-volumes` patch points.