### PR TITLE
feat: add mfe-k8s-volume-mounts patch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -517,21 +517,33 @@ Then add your static files using volume patches. For local deployments, use the 
         )
     )
 
-For Kubernetes deployments, use the ``mfe-k8s-volumes`` patch:
+For Kubernetes deployments, use the ``mfe-k8s-volumes`` patch to define the volumes you need, and mount them using the ``mfe-k8s-volume-mounts`` patch:
+
+For example, to mount a ConfigMap at ``/usr/share/caddy/myfiles`` so it’s served at ``/myfiles/*``:
 
 .. code-block:: python
 
-    hooks.Filters.ENV_PATCHES.add_item(
-        (
-            "mfe-k8s-volumes",
-            """
-            # Add your custom volume definition here. This can be any valid Kubernetes volume type.
-            - name: myfiles-volume
-              configMap:
-                  name: myfiles-configmap
-                  ...
-            """
-        )
+    from tutor import hooks
+
+    hooks.Filters.ENV_PATCHES.add_items(
+        [
+            (
+                "mfe-k8s-volumes",
+                """
+                - name: myfiles-volume
+                  configMap:
+                    name: myfiles-configmap
+                """
+            ),
+            (
+                "mfe-k8s-volume-mounts",
+                """
+                - name: myfiles-volume
+                  mountPath: /usr/share/caddy/myfiles
+                  readOnly: true
+                """
+            ),
+        ]
     )
 
 Your static files will be accessible at ``http(s)://{{ MFE_HOST }}/myfiles/``.
@@ -843,6 +855,14 @@ mfe-k8s-volumes
 ~~~~~~~~~~~~~~~
 
 Add volumes to the mfe deployment in Kubernetes.
+
+File changed: ``k8s/deployments.yml``
+
+
+mfe-k8s-volume-mounts
+~~~~~~~~~~~~~~~~~~~~~
+
+Add volume mounts to the ``mfe`` container in the Kubernetes deployment. Use this together with ``mfe-k8s-volumes`` to attach and mount custom volumes (e.g., ConfigMaps, PVCs) inside the container.
 
 File changed: ``k8s/deployments.yml``
 

--- a/changelog.d/20250901_141842_andres.giraldo_volume_mounts_patch.md
+++ b/changelog.d/20250901_141842_andres.giraldo_volume_mounts_patch.md
@@ -1,0 +1,1 @@
+- [Feature] Add `mfe-k8s-volume-mounts` patch to mount volumes in the MFE Kubernetes Deployment, complementing `mfe-k8s-volumes`. (by @andres.giraldo)

--- a/tutormfe/patches/k8s-deployments
+++ b/tutormfe/patches/k8s-deployments
@@ -22,6 +22,9 @@ spec:
           volumeMounts:
             - mountPath: /etc/caddy/
               name: config
+          {%- if MFE_HOST_EXTRA_FILES %}
+            {{ patch("mfe-k8s-volume-mounts") | indent(12) }}
+          {%- endif %}
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
## Description

This pull request introduces a new patch, `mfe-k8s-volume-mounts`, to improve how custom volumes are mounted in the MFE Kubernetes deployment. Now that the host extra file changes were applied at #264, I noticed that there was no patch referencing the volume mounts, which prevented the `mfe-k8s-volumes` patch from actually being applied in Kubernetes environments. 

The documentation has been updated to guide users on defining and mounting volumes using the new patch, and a changelog entry records the addition.

> [!NOTE]
> This patch is necessary for `mfe-k8s-volumes` to work properly, as the corresponding volume mount patch was previously missing.

For further information about the importance of this PR, please take a look at: [feat: add volume patches to mfe service and k8s #264](https://github.com/overhangio/tutor-mfe/pull/264)

### Changes

* Added the `mfe-k8s-volume-mounts` patch to allow mounting custom volumes (such as ConfigMaps or PVCs) into the `mfe` container in Kubernetes deployments, complementing the existing `mfe-k8s-volumes` patch. (`tutormfe/patches/k8s-deployments`)
* Updated the documentation to explain how to use both `mfe-k8s-volumes` and `mfe-k8s-volume-mounts` together, including a practical example for mounting a ConfigMap.
* Added a new section in the documentation describing the purpose and usage of the `mfe-k8s-volume-mounts` patch. (`README.rst`)

