### PR TITLE
feat: Upgrade to Node 24

### DIFF
--- a/changelog.d/20251029_064630_diana.olarte_add_admin_console.md
+++ b/changelog.d/20251029_064630_diana.olarte_add_admin_console.md
@@ -1,1 +1,1 @@
-[Feature] Add admin-console to the core list of microfrontends. (by @dcoa)
+- [Improvement] Add admin-console to the core list of microfrontends. (by @dcoa)

--- a/changelog.d/20251030_103101_arbrandes_node24.md
+++ b/changelog.d/20251030_103101_arbrandes_node24.md
@@ -1,0 +1,1 @@
+- [Improvement] Upgrade to Node 24. (by @arbrandes)

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # https://hub.docker.com/_/node/tags
-FROM docker.io/node:20.18.0-bullseye-slim AS base
+FROM docker.io/node:24.11.0-bullseye-slim AS base
 
 RUN apt update \
   && apt install -y git \


### PR DESCRIPTION
Now that https://github.com/openedx/public-engineering/issues/407 is done as far as Tutor MFEs are concerned, we can upgrade the base image to Node 24.

I tested this locally and did not encounter any build issues.