### PR TITLE
[WIP] Build process for frontendbase apps alternative explicit version

### DIFF
--- a/tutormfe/hooks.py
+++ b/tutormfe/hooks.py
@@ -11,7 +11,13 @@ import typing as t
 from tutor.core.hooks import Filter
 
 MFE_ATTRS_TYPE = t.Dict[t.Literal["repository", "port", "version"], t.Union["str", int]]
+FRONTEND_TEMPLATE_SITE_ATTRS_TYPE = t.Dict[t.Literal["repository", "version"], t.Union["str", int]]
 
 MFE_APPS: Filter[dict[str, MFE_ATTRS_TYPE], []] = Filter()
+
+# This will hold the frontent-template-site like repos (ideally one)
+FRONTEND_BASE_APPS: Filter[dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE], []] = Filter()
+# This will hold the list of which apps are "enabled" so we can switch between mfe and frontend-base ones
+FRONTEND_APPS: Filter[dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE], []] = Filter()
 
 PLUGIN_SLOTS: Filter[list[tuple[str, str, str]], []] = Filter()

--- a/tutormfe/hooks.py
+++ b/tutormfe/hooks.py
@@ -11,11 +11,12 @@ import typing as t
 from tutor.core.hooks import Filter
 
 MFE_ATTRS_TYPE = t.Dict[t.Literal["repository", "port", "version"], t.Union["str", int]]
-FRONTEND_TEMPLATE_SITE_ATTRS_TYPE = t.Dict[t.Literal["repository", "version"], t.Union["str", int]]
+FRONTEND_TEMPLATE_SITE_ATTRS_TYPE = t.Dict
 
 MFE_APPS: Filter[dict[str, MFE_ATTRS_TYPE], []] = Filter()
 
-# TODO: This will hold the list of which apps are "enabled" so we can switch between mfe and frontend-base ones
-FRONTEND_APPS: Filter[dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE], []] = Filter()
+# TODO: This will hold the list of which apps are "enabled" so we can switch between mfe
+# and frontend-base ones
+FRONTEND_APPS: Filter[dict[str, t.Dict], []] = Filter()
 
 PLUGIN_SLOTS: Filter[list[tuple[str, str, str]], []] = Filter()

--- a/tutormfe/hooks.py
+++ b/tutormfe/hooks.py
@@ -15,9 +15,7 @@ FRONTEND_TEMPLATE_SITE_ATTRS_TYPE = t.Dict[t.Literal["repository", "version"], t
 
 MFE_APPS: Filter[dict[str, MFE_ATTRS_TYPE], []] = Filter()
 
-# This will hold the frontent-template-site like repos (ideally one)
-FRONTEND_BASE_APPS: Filter[dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE], []] = Filter()
-# This will hold the list of which apps are "enabled" so we can switch between mfe and frontend-base ones
+# TODO: This will hold the list of which apps are "enabled" so we can switch between mfe and frontend-base ones
 FRONTEND_APPS: Filter[dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE], []] = Filter()
 
 PLUGIN_SLOTS: Filter[list[tuple[str, str, str]], []] = Filter()

--- a/tutormfe/hooks.py
+++ b/tutormfe/hooks.py
@@ -10,13 +10,17 @@ import typing as t
 
 from tutor.core.hooks import Filter
 
-MFE_ATTRS_TYPE = t.Dict[t.Literal["repository", "port", "version"], t.Union["str", int]]
-FRONTEND_TEMPLATE_SITE_ATTRS_TYPE = t.Dict
+MFE_ATTRS_TYPE = t.Dict[
+    t.Literal["repository", "port", "version"], t.Union["str", int]
+]
+FRONTEND_TEMPLATE_SITE_ATTRS_TYPE = t.Dict[
+    t.Literal["repository", "version"], t.Union["str", int]
+]
 
 MFE_APPS: Filter[dict[str, MFE_ATTRS_TYPE], []] = Filter()
 
 # TODO: This will hold the list of which apps are "enabled" so we can switch between mfe
 # and frontend-base ones
-FRONTEND_APPS: Filter[dict[str, t.Dict], []] = Filter()
+FRONTEND_APPS: Filter[dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE], []] = Filter()
 
 PLUGIN_SLOTS: Filter[list[tuple[str, str, str]], []] = Filter()

--- a/tutormfe/patches/mfe-dockerfile-pre-npm-install-template-site
+++ b/tutormfe/patches/mfe-dockerfile-pre-npm-install-template-site
@@ -1,3 +1,0 @@
-# Copy packs directory before npm install for template-site
-# This is needed because template-site has local file dependencies in its package.json
-COPY --from=template-site-src /packs /openedx/app/packs

--- a/tutormfe/patches/mfe-dockerfile-pre-npm-install-template-site
+++ b/tutormfe/patches/mfe-dockerfile-pre-npm-install-template-site
@@ -1,0 +1,3 @@
+# Copy packs directory before npm install for template-site
+# This is needed because template-site has local file dependencies in its package.json
+COPY --from=template-site-src /packs /openedx/app/packs

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -115,17 +115,16 @@ def get_frontend_apps(apps_to_build: bool = False) -> dict[str, FRONTEND_TEMPLAT
     all_frontend_apps = FRONTEND_APPS.apply({})
 
     if not apps_to_build:
-        return {}
+        return all_frontend_apps
 
     # When returning apps to build we only return the ones that have a repository defined
     # (those are the ones to be built) and we prefix the name
     # with "frontend-app-" to avoid conflicts with MFE names
-    apps_to_return = {
+    return {
         f"frontend-app-{name}": attrs 
         for name, attrs in all_frontend_apps.items() 
         if "repository" in attrs
     }
-    return apps_to_return
 
 
 @tutor_hooks.lru_cache

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -13,7 +13,7 @@ from tutor.hooks import priorities
 from tutor.types import Config, get_typed
 
 from .__about__ import __version__
-from .hooks import MFE_APPS, MFE_ATTRS_TYPE, FRONTEND_BASE_APPS, FRONTEND_APPS, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE, PLUGIN_SLOTS
+from .hooks import MFE_APPS, MFE_ATTRS_TYPE, FRONTEND_APPS, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE, PLUGIN_SLOTS
 
 # Handle version suffix in main mode, just like tutor core
 if __version_suffix__:
@@ -78,8 +78,8 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
     },
     "template-site": {
         "repository": "https://github.com/WGU-Open-edX/frontend-template-site.git",
+        "version": "initial",
         "port": 8080,
-        "frontend_base_app": True,  # Mark this app as a frontend base app maybe (?)
     } 
 }
 

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -5,7 +5,7 @@ import typing as t
 from glob import glob
 
 import importlib_resources
-from tutor import fmt
+from tutor import fmt, config as tutor_config
 from tutor import hooks as tutor_hooks
 from tutor.__about__ import __version_suffix__
 from tutor.bindmount import iter_mounts
@@ -13,7 +13,7 @@ from tutor.hooks import priorities
 from tutor.types import Config, get_typed
 
 from .__about__ import __version__
-from .hooks import MFE_APPS, MFE_ATTRS_TYPE, PLUGIN_SLOTS
+from .hooks import MFE_APPS, MFE_ATTRS_TYPE, FRONTEND_BASE_APPS, FRONTEND_APPS, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE, PLUGIN_SLOTS
 
 # Handle version suffix in main mode, just like tutor core
 if __version_suffix__:
@@ -95,6 +95,14 @@ def get_mfes() -> dict[str, MFE_ATTRS_TYPE]:
     return MFE_APPS.apply({})
 
 
+@tutor_hooks.lru_cache
+def get_frontend_apps() -> dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]:
+    """
+    This function is cached for performance.
+    """
+    return FRONTEND_APPS.apply({})
+
+
 class MFEMountData:
     """Stores categorized mounted and unmounted MFEs."""
 
@@ -129,6 +137,14 @@ def iter_mfes() -> t.Iterable[tuple[str, MFE_ATTRS_TYPE]]:
     """
     yield from get_mfes().items()
 
+def iter_frontent_apps() -> t.Iterable[tuple[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]:
+    """
+    Yield:
+
+        (name, dict)
+    """
+    yield from get_frontend_apps().items()
+
 
 def iter_plugin_slots(mfe_name: str) -> t.Iterable[tuple[str, str]]:
     """
@@ -142,6 +158,9 @@ def iter_plugin_slots(mfe_name: str) -> t.Iterable[tuple[str, str]]:
 def is_mfe_enabled(mfe_name: str) -> bool:
     return mfe_name in get_mfes()
 
+def is_frontend_app_enabled(app_name: str) -> bool:
+    return app_name in get_frontend_apps()
+
 
 def get_mfe(mfe_name: str) -> t.Union[MFE_ATTRS_TYPE, t.Any]:
     return get_mfes().get(mfe_name, {})
@@ -152,8 +171,10 @@ tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
     [
         ("get_mfe", get_mfe),
         ("iter_mfes", iter_mfes),
+        ("iter_frontend_apps", iter_frontent_apps),
         ("iter_plugin_slots", iter_plugin_slots),
         ("is_mfe_enabled", is_mfe_enabled),
+        ("is_frontend_app_enabled", is_frontend_app_enabled),
         ("MFEMountData", MFEMountData),
     ]
 )
@@ -217,6 +238,7 @@ with open(
     tutor_hooks.Filters.CLI_DO_INIT_TASKS.add_item(("lms", task_file.read()))
 
 REPO_PREFIX = "frontend-app-"
+FRONTEND_TEMPLATE_SITE_REPO = "frontend-template-site"
 
 
 @tutor_hooks.Filters.COMPOSE_MOUNTS.add()

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -142,13 +142,28 @@ def iter_mfes() -> t.Iterable[tuple[str, MFE_ATTRS_TYPE]]:
     """
     yield from get_mfes().items()
 
-def iter_frontent_apps() -> t.Iterable[tuple[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]:
+# Iter throgh all mfes and adds the unique frontend apps,
+# so we can have a list of all the things that are unique that needs
+# to be added to Caddyfile, for example instructor dashboard that was 
+# created as frontend-base app but didn't exist as a MFE before
+# so it returns the whole mfes list plus the unique frontend apps that are not in the mfe list
+def iter_frontend_apps() -> t.Iterable[tuple[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]:
     """
     Yield:
 
         (name, dict)
     """
-    yield from get_frontend_apps().items()
+    mfes = get_mfes()
+    frontend_apps = get_frontend_apps()
+    
+    # First yield all MFEs
+    for name, attrs in mfes.items():
+        yield (name, attrs)
+    
+    # Then yield frontend apps that are not already MFEs
+    for name, attrs in frontend_apps.items():
+        if name not in mfes:
+            yield (name, attrs)
 
 
 def iter_plugin_slots(mfe_name: str) -> t.Iterable[tuple[str, str]]:
@@ -176,7 +191,7 @@ tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
     [
         ("get_mfe", get_mfe),
         ("iter_mfes", iter_mfes),
-        ("iter_frontend_apps", iter_frontent_apps),
+        ("iter_frontend_apps", iter_frontend_apps),
         ("iter_plugin_slots", iter_plugin_slots),
         ("is_mfe_enabled", is_mfe_enabled),
         ("is_frontend_app_enabled", is_frontend_app_enabled),

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -113,14 +113,18 @@ def get_frontend_apps(apps_to_build: bool = False) -> dict[str, FRONTEND_TEMPLAT
     This function is cached for performance.
     """
     all_frontend_apps = FRONTEND_APPS.apply({})
-    parsed_apps: dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE] = {}
-    for name, attrs in all_frontend_apps.items():
-        parsed_apps[f"frontend-app-{name}"] = attrs
+
     if not apps_to_build:
-        return parsed_apps
-    
-    apps_to_return = {name: attrs for name, attrs in parsed_apps.items() if "repository" in attrs}
-    # If apps_to_build is True, then we only want to return the frontend apps that have a repository
+        return {}
+
+    # When returning apps to build we only return the ones that have a repository defined
+    # (those are the ones to be built) and we prefix the name
+    # with "frontend-app-" to avoid conflicts with MFE names
+    apps_to_return = {
+        f"frontend-app-{name}": attrs 
+        for name, attrs in all_frontend_apps.items() 
+        if "repository" in attrs
+    }
     return apps_to_return
 
 
@@ -133,7 +137,7 @@ def get_all_apps() -> dict[str, t.Union[MFE_ATTRS_TYPE, FRONTEND_TEMPLATE_SITE_A
     all_apps = get_frontend_apps(apps_to_build=True).copy()
     mfes = get_mfes()
     all_apps.update(mfes)
-    
+
     # ensure frontend-template-site is the last one on the all_apps dict
     if "template-site" in all_apps:
         all_apps["template-site"] = all_apps.pop("template-site")

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -76,11 +76,11 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
         "repository": "https://github.com/openedx/frontend-app-profile.git",
         "port": 1995,
     },
-    "template-site": {
-        "repository": "https://github.com/WGU-Open-edX/frontend-template-site.git",
-        "version": "initial",
-        "port": 8080,
-    } 
+    # "template-site": {
+    #     "repository": "https://github.com/WGU-Open-edX/frontend-template-site.git",
+    #     "version": "initial",
+    #     "port": 8080,
+    # } 
 }
 
 
@@ -100,13 +100,45 @@ def get_mfes() -> dict[str, MFE_ATTRS_TYPE]:
     return MFE_APPS.apply({})
 
 
+# List will need
+## Apps that are only frontend-apps
+## Apps that are only MFEs
+## Apps with unique ones (all old mfes + instruct)
+## 1 and 2 with 1 having something like a different identifier
+
+
 @tutor_hooks.lru_cache
-def get_frontend_apps() -> dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]:
+def get_frontend_apps(apps_to_build: bool = False) -> dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]:
     """
     This function is cached for performance.
     """
-    return FRONTEND_APPS.apply({})
+    all_frontend_apps = FRONTEND_APPS.apply({})
+    parsed_apps: dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE] = {}
+    for name, attrs in all_frontend_apps.items():
+        parsed_apps[f"frontend-app-{name}"] = attrs
+    if not apps_to_build:
+        return parsed_apps
+    
+    apps_to_return = {name: attrs for name, attrs in parsed_apps.items() if "repository" in attrs}
+    # If apps_to_build is True, then we only want to return the frontend apps that have a repository
+    return apps_to_return
 
+
+@tutor_hooks.lru_cache
+def get_all_apps() -> dict[str, t.Union[MFE_ATTRS_TYPE, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]:
+    """
+    This function is cached for performance.
+    """
+    # IMPORTANT: Make a copy to avoid mutating the cached result from get_frontend_apps()
+    all_apps = get_frontend_apps(apps_to_build=True).copy()
+    mfes = get_mfes()
+    all_apps.update(mfes)
+    
+    # ensure frontend-template-site is the last one on the all_apps dict
+    if "template-site" in all_apps:
+        all_apps["template-site"] = all_apps.pop("template-site")
+
+    return all_apps
 
 class MFEMountData:
     """Stores categorized mounted and unmounted MFEs."""
@@ -147,7 +179,7 @@ def iter_mfes() -> t.Iterable[tuple[str, MFE_ATTRS_TYPE]]:
 # to be added to Caddyfile, for example instructor dashboard that was 
 # created as frontend-base app but didn't exist as a MFE before
 # so it returns the whole mfes list plus the unique frontend apps that are not in the mfe list
-def iter_frontend_apps() -> t.Iterable[tuple[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]:
+def iter_unique_apps() -> t.Iterable[tuple[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]:
     """
     Yield:
 
@@ -165,6 +197,27 @@ def iter_frontend_apps() -> t.Iterable[tuple[str, FRONTEND_TEMPLATE_SITE_ATTRS_T
         if name not in mfes:
             yield (name, attrs)
 
+# Iters through all apps that will be built
+def iter_all_apps() -> t.Iterable[tuple[str, t.Union[MFE_ATTRS_TYPE, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]]:
+    """
+    Yield:
+
+        (name, dict)
+    """
+    all_apps = get_all_apps()
+    for name, attrs in all_apps.items():
+        yield (name, attrs)
+
+def iter_frontend_apps_to_build() -> t.Iterable[tuple[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]:
+    """
+    Yield:
+
+        (name, dict)
+    """
+    frontend_apps = get_frontend_apps(apps_to_build=True)
+    for name, attrs in frontend_apps.items():
+        yield (name, attrs)
+
 
 def iter_plugin_slots(mfe_name: str) -> t.Iterable[tuple[str, str]]:
     """
@@ -181,6 +234,8 @@ def is_mfe_enabled(mfe_name: str) -> bool:
 def is_frontend_app_enabled(app_name: str) -> bool:
     return app_name in get_frontend_apps()
 
+def is_frontend_app_to_build(app_name: str) -> bool:
+    return app_name in get_frontend_apps(apps_to_build=True)
 
 def get_mfe(mfe_name: str) -> t.Union[MFE_ATTRS_TYPE, t.Any]:
     return get_mfes().get(mfe_name, {})
@@ -191,10 +246,13 @@ tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
     [
         ("get_mfe", get_mfe),
         ("iter_mfes", iter_mfes),
-        ("iter_frontend_apps", iter_frontend_apps),
+        ("iter_unique_apps", iter_unique_apps),
+        ("iter_all_apps", iter_all_apps),
+        ("iter_frontend_apps_to_build", iter_frontend_apps_to_build),
         ("iter_plugin_slots", iter_plugin_slots),
         ("is_mfe_enabled", is_mfe_enabled),
         ("is_frontend_app_enabled", is_frontend_app_enabled),
+        ("is_frontend_app_to_build", is_frontend_app_to_build),
         ("MFEMountData", MFEMountData),
     ]
 )

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -76,6 +76,11 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
         "repository": "https://github.com/openedx/frontend-app-profile.git",
         "port": 1995,
     },
+    "template-site": {
+        "repository": "https://github.com/WGU-Open-edX/frontend-template-site.git",
+        "port": 8080,
+        "frontend_base_app": True,  # Mark this app as a frontend base app maybe (?)
+    } 
 }
 
 
@@ -238,7 +243,8 @@ with open(
     tutor_hooks.Filters.CLI_DO_INIT_TASKS.add_item(("lms", task_file.read()))
 
 REPO_PREFIX = "frontend-app-"
-FRONTEND_TEMPLATE_SITE_REPO = "frontend-template-site"
+# TODO: for now leave this and then find better semantic namings
+FRONTEND_TEMPLATE_SITE_PREFIX = "frontend-"
 
 
 @tutor_hooks.Filters.COMPOSE_MOUNTS.add()
@@ -251,12 +257,12 @@ def _mount_frontend_apps(
     in dev mode, because in production, all MFEs are built and hosted on the
     singular 'mfe' service container.
     """
-    if path_basename.startswith(REPO_PREFIX):
+    if path_basename.startswith(REPO_PREFIX) or path_basename.startswith(FRONTEND_TEMPLATE_SITE_PREFIX):
         # Assumption:
         # For each repo named frontend-app-APPNAME, there is an associated
         # docker-compose service named APPNAME. If this assumption is broken,
         # then Tutor will try to mount the repo in a service that doesn't exist.
-        app_name = path_basename[len(REPO_PREFIX) :]
+        app_name = path_basename[len(REPO_PREFIX) :] if path_basename.startswith(REPO_PREFIX) else path_basename[len(FRONTEND_TEMPLATE_SITE_PREFIX) :]
         volumes += [(app_name, "/openedx/app")]
     return volumes
 
@@ -266,9 +272,9 @@ def _mount_frontend_apps_on_build(
     mounts: list[tuple[str, str]], host_path: str
 ) -> list[tuple[str, str]]:
     path_basename = os.path.basename(host_path)
-    if path_basename.startswith(REPO_PREFIX):
+    if path_basename.startswith(REPO_PREFIX) or path_basename.startswith(FRONTEND_TEMPLATE_SITE_PREFIX):
         # Bind-mount repo at build-time, both for prod and dev images
-        app_name = path_basename[len(REPO_PREFIX) :]
+        app_name = path_basename[len(REPO_PREFIX) :] if path_basename.startswith(REPO_PREFIX) else path_basename[len(FRONTEND_TEMPLATE_SITE_PREFIX) :]
         mounts.append(("mfe", f"{app_name}-src"))
         mounts.append((f"{app_name}-dev", f"{app_name}-src"))
     return mounts

--- a/tutormfe/templates/mfe/apps/mfe/Caddyfile
+++ b/tutormfe/templates/mfe/apps/mfe/Caddyfile
@@ -1,6 +1,3 @@
-{
-    debug
-}
 :8002 {
     log {
         output stdout

--- a/tutormfe/templates/mfe/apps/mfe/Caddyfile
+++ b/tutormfe/templates/mfe/apps/mfe/Caddyfile
@@ -1,3 +1,6 @@
+{
+    debug
+}
 :8002 {
     log {
         output stdout
@@ -27,6 +30,7 @@
     {% endif %}
 
     {% for app_name, app in iter_mfes() %}
+    {% if app_name != "template-site" %}
     @mfe_{{ app_name }} {
         path /{{ app_name }} /{{ app_name }}/*
     }
@@ -34,7 +38,7 @@
         uri strip_prefix /{{ app_name }}
         {%- if is_frontend_app_enabled(app_name) %}
         # {{ app_name }} - using frontend-apps approach
-        root * /openedx/dist/frontend-template-site
+        root * /openedx/dist/template-site
         {%- else %}
         # {{ app_name }} - using traditional MFE approach
         root * /openedx/dist/{{ app_name }}
@@ -42,5 +46,17 @@
         try_files /{path} /index.html
         file_server
     }
+    {# TODO: Temporal while better rules are in place #}
+    {% else %}
+    @mfe_{{ app_name }} {
+        path / /*
+    }
+    handle @mfe_{{ app_name }} {
+        root * /openedx/dist/template-site
+        try_files /{path} /index.html
+        file_server
+    }
+    {% endif %}
+
     {% endfor %}
 }

--- a/tutormfe/templates/mfe/apps/mfe/Caddyfile
+++ b/tutormfe/templates/mfe/apps/mfe/Caddyfile
@@ -32,7 +32,13 @@
     }
     handle @mfe_{{ app_name }} {
         uri strip_prefix /{{ app_name }}
+        {%- if is_frontend_app_enabled(app_name) %}
+        # {{ app_name }} - using frontend-apps approach
+        root * /openedx/dist/frontend-template-site
+        {%- else %}
+        # {{ app_name }} - using traditional MFE approach
         root * /openedx/dist/{{ app_name }}
+        {%- endif %}
         try_files /{path} /index.html
         file_server
     }

--- a/tutormfe/templates/mfe/apps/mfe/Caddyfile
+++ b/tutormfe/templates/mfe/apps/mfe/Caddyfile
@@ -26,7 +26,7 @@
     redir @authoring /authoring/{re.authoring.1} permanent
     {% endif %}
 
-    {% for app_name, app in iter_frontend_apps() %}
+    {% for app_name, app in iter_unique_apps() %}
     @mfe_{{ app_name }} {
         path /{{ app_name }} /{{ app_name }}/*
     }

--- a/tutormfe/templates/mfe/apps/mfe/Caddyfile
+++ b/tutormfe/templates/mfe/apps/mfe/Caddyfile
@@ -29,7 +29,7 @@
     redir @authoring /authoring/{re.authoring.1} permanent
     {% endif %}
 
-    {% for app_name, app in iter_mfes() %}
+    {% for app_name, app in iter_frontend_apps() %}
     @mfe_{{ app_name }} {
         path /{{ app_name }} /{{ app_name }}/*
     }

--- a/tutormfe/templates/mfe/apps/mfe/Caddyfile
+++ b/tutormfe/templates/mfe/apps/mfe/Caddyfile
@@ -30,7 +30,6 @@
     {% endif %}
 
     {% for app_name, app in iter_mfes() %}
-    {% if app_name != "template-site" %}
     @mfe_{{ app_name }} {
         path /{{ app_name }} /{{ app_name }}/*
     }
@@ -46,17 +45,6 @@
         try_files /{path} /index.html
         file_server
     }
-    {# TODO: Temporal while better rules are in place #}
-    {% else %}
-    @mfe_{{ app_name }} {
-        path / /*
-    }
-    handle @mfe_{{ app_name }} {
-        root * /openedx/dist/template-site
-        try_files /{path} /index.html
-        file_server
-    }
-    {% endif %}
 
     {% endfor %}
 }

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -22,7 +22,7 @@ ENV PATH=/openedx/app/node_modules/.bin:${PATH}
 
 {{ patch("mfe-dockerfile-base") }}
 
-{% for app_name, app in iter_mfes() %}
+{% for app_name, app in iter_all_apps() %}
 ####################### {{ app_name }} MFE
 ######## {{ app_name }} (git)
 FROM base AS {{ app_name }}-git
@@ -50,10 +50,10 @@ RUN --mount=type=cache,target=/root/.npm,sharing=shared npm clean-install --no-a
 {{ patch("mfe-dockerfile-post-npm-install-{}".format(app_name)) }}
 COPY --from={{ app_name }}-src / /openedx/app
 
+# While we figure out how translations will be managed  in template site
 {% if app_name != "template-site" %}
 RUN make OPENEDX_ATLAS_PULL=true ATLAS_OPTIONS="--repository={{ ATLAS_REPOSITORY }} --revision={{ ATLAS_REVISION }} {{ ATLAS_OPTIONS }}" pull_translations
 {% endif %}
-EXPOSE {{ app['port'] }}
 
 # Configuration needed at build time
 ENV APP_ID={{ app_name }}
@@ -67,6 +67,12 @@ COPY env.config.jsx /openedx/app
 {{ patch("mfe-dockerfile-pre-npm-build") }}
 {{ patch("mfe-dockerfile-pre-npm-build-{}".format(app_name)) }}
 
+{% if is_frontend_app_to_build(app_name) %}
+RUN TGZ_FILE=$(npm pack) && mv "$TGZ_FILE" {{app_name}}.tgz
+{% else %}
+EXPOSE {{ app['port'] }}
+{% endif %}
+
 ######## {{ app_name }} (dev)
 FROM {{ app_name }}-common AS {{ app_name }}-dev
 ENV NODE_ENV=development
@@ -77,6 +83,16 @@ CMD ["/bin/bash", "-c", "npm run start --- --config ./webpack.dev-tutor.config.j
 {%- for app_name, app in iter_mfes() %}
 ######## {{ app_name }} (production)
 FROM {{ app_name }}-common AS {{ app_name }}-prod
+
+{% if app_name == "template-site" %}
+    RUN mkdir -p /openedx/app/pack
+  {%- for app_name, app in iter_frontend_apps_to_build() %}
+    COPY --from={{ app_name }}-common /openedx/app/{{app_name}}.tgz /openedx/app/pack/
+    RUN npm install /openedx/app/pack/{{app_name}}.tgz --no-audit --no-fund
+  {% endfor %}
+  RUN npm ci
+{% endif %}
+
 ENV NODE_ENV=production
 RUN npm run build
 {{ patch("mfe-dockerfile-post-npm-build") }}

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -50,8 +50,9 @@ RUN --mount=type=cache,target=/root/.npm,sharing=shared npm clean-install --no-a
 {{ patch("mfe-dockerfile-post-npm-install-{}".format(app_name)) }}
 COPY --from={{ app_name }}-src / /openedx/app
 
+{% if app_name != "template-site" %}
 RUN make OPENEDX_ATLAS_PULL=true ATLAS_OPTIONS="--repository={{ ATLAS_REPOSITORY }} --revision={{ ATLAS_REVISION }} {{ ATLAS_OPTIONS }}" pull_translations
-
+{% endif %}
 EXPOSE {{ app['port'] }}
 
 # Configuration needed at build time

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -51,7 +51,8 @@ RUN --mount=type=cache,target=/root/.npm,sharing=shared npm clean-install --no-a
 COPY --from={{ app_name }}-src / /openedx/app
 
 # While we figure out how translations will be managed  in template site
-{% if app_name != "template-site" %}
+# if it's either template-site or starts with frontend-app, we skip pulling translations
+{% if app_name != "template-site" and not app_name.startswith("frontend-app") %}
 RUN make OPENEDX_ATLAS_PULL=true ATLAS_OPTIONS="--repository={{ ATLAS_REPOSITORY }} --revision={{ ATLAS_REVISION }} {{ ATLAS_OPTIONS }}" pull_translations
 {% endif %}
 
@@ -68,7 +69,7 @@ COPY env.config.jsx /openedx/app
 {{ patch("mfe-dockerfile-pre-npm-build-{}".format(app_name)) }}
 
 {% if is_frontend_app_to_build(app_name) %}
-RUN TGZ_FILE=$(npm pack) && mv "$TGZ_FILE" {{app_name}}.tgz
+RUN npm pack && mv *.tgz {{app_name}}.tgz
 {% else %}
 EXPOSE {{ app['port'] }}
 {% endif %}


### PR DESCRIPTION
## Basic details
This is the first step for the build process of the frontend apps

- Adds a new filter that will be used to know which apps should be frontendbase
- Adds a patch to prevent translations being pulled for template site (while I figure out how that should work)
- Modify a couple of utility functions to allow frontent-template-site to be mounted (while we agree on specific semantics)
- Modifies Caddyfile so if the app is a frontentbase it directs to template-site instead of the old app folder
- installs all the frontendapps that are configured with a repository attribute which means they need to be build explicitly, pack and installed on template site

## Assumptions
This use multi stage builds if there's frontend apps that have the repository attribute configured which means that if you manually declare a repository for those apps the process will try to build it, pack it and install it.

** This may be network / RAM intensive ** so in case you run into something like:

<img width="690" height="407" alt="image" src="https://github.com/user-attachments/assets/9f73e900-a5ae-485b-9a0c-ae85d70ba89b" />

disable a couple MFEs or reduce the amount of parallelism in docker build config (details about this can be found at the readme [look for parallelism in the dev section](https://github.com/overhangio/tutor-mfe?tab=readme-ov-file#mfe-development))

Also for now, the aggregator repo needs to have the same public path as the app_name for the app in this case and for now that's template-site which means `PUBLIC_PATH=/template-site/` because that will allow all the assets to be served properly.



## How to add a frontendapp
In order to mark something as a frontendbase app you need a plugin that looks like:

```py
from tutormfe.hooks import FRONTEND_APPS

@FRONTEND_APPS.add()
def _add_frontend_apps(apps):
    apps["learner-dashboard"] = {}
    apps["authn"] = {}
    apps["instructor"] = {} 
    return apps
```

and if you need some of those to be manually build and installed in the template site:

```py
@FRONTEND_APPS.add()
def _add_frontend_apps(apps):
    apps["learner-dashboard"] = {
        "repository": "https://github.com/openedx/frontend-app-learner-dashboard.git",
        "version": "frontend-base",
        "port": "8080",
    }
    apps["authn"] = {
        "repository": "https://github.com/openedx/frontend-app-authn.git",
        "version": "frontend-base",
        "port": "8080",
    }
    return apps
```

_notice that the `port`is there but it's just to match the contract for the Dockerfile_ 

Any app that it's on this list will be considered a fronend-app so when Caddy shows the content for it, it will show the one on template-site instead of the normal app.