### PR TITLE
[WIP] Build process for frontendbase apps npm workspaces flavor (aka: the good one)

### DIFF
--- a/tutormfe/hooks.py
+++ b/tutormfe/hooks.py
@@ -31,3 +31,5 @@ FRONTEND_APPS: Filter[dict[str, FRONTEND_APP_ATTRS_TYPE], []] = Filter()
 FRONTEND_SITES: Filter[dict[str, FRONTEND_APP_ATTRS_TYPE], []] = Filter()
 
 PLUGIN_SLOTS: Filter[list[tuple[str, str, str]], []] = Filter()
+
+FRONTEND_SLOTS: Filter[list[tuple[str, str]], []] = Filter()

--- a/tutormfe/hooks.py
+++ b/tutormfe/hooks.py
@@ -11,8 +11,16 @@ import typing as t
 from tutor.core.hooks import Filter
 
 MFE_ATTRS_TYPE = t.Dict[t.Literal["repository", "port", "version"], t.Union["str", int]]
+
+# Extended MFE type that includes externalRoutes
+SITE_ATTRS_TYPE = t.Dict[
+    t.Literal["repository", "port", "version"],
+    t.Union[str, int],
+]
+
 FRONTEND_APP_ATTRS_TYPE = t.Dict[
-    t.Literal["repository", "version", "site"], t.Union["str", int]
+    t.Literal["repository", "version", "site", "appEntryPoints", "appId"],
+    t.Union["str", int, dict],
 ]
 
 MFE_APPS: Filter[dict[str, MFE_ATTRS_TYPE], []] = Filter()

--- a/tutormfe/hooks.py
+++ b/tutormfe/hooks.py
@@ -11,7 +11,13 @@ import typing as t
 from tutor.core.hooks import Filter
 
 MFE_ATTRS_TYPE = t.Dict[t.Literal["repository", "port", "version"], t.Union["str", int]]
+FRONTEND_TEMPLATE_SITE_ATTRS_TYPE = t.Dict[t.Literal["repository", "version"], t.Union["str", int]]
 
 MFE_APPS: Filter[dict[str, MFE_ATTRS_TYPE], []] = Filter()
+
+# This will hold the frontent-template-site like repos (ideally one)
+FRONTEND_BASE_APPS: Filter[dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE], []] = Filter()
+# This will hold the list of which apps are "enabled" so we can switch between mfe and frontend-base ones
+FRONTEND_APPS: Filter[dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE], []] = Filter()
 
 PLUGIN_SLOTS: Filter[list[tuple[str, str, str]], []] = Filter()

--- a/tutormfe/hooks.py
+++ b/tutormfe/hooks.py
@@ -11,11 +11,12 @@ import typing as t
 from tutor.core.hooks import Filter
 
 MFE_ATTRS_TYPE = t.Dict[t.Literal["repository", "port", "version"], t.Union["str", int]]
-FRONTEND_TEMPLATE_SITE_ATTRS_TYPE = t.Dict[t.Literal["repository", "version"], t.Union["str", int]]
+FRONTEND_TEMPLATE_SITE_ATTRS_TYPE = t.Dict
 
 MFE_APPS: Filter[dict[str, MFE_ATTRS_TYPE], []] = Filter()
 
-# TODO: This will hold the list of which apps are "enabled" so we can switch between mfe and frontend-base ones
-FRONTEND_APPS: Filter[dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE], []] = Filter()
+# TODO: This will hold the list of which apps are "enabled" so we can switch between mfe
+# and frontend-base ones
+FRONTEND_APPS: Filter[dict[str, t.Dict], []] = Filter()
 
 PLUGIN_SLOTS: Filter[list[tuple[str, str, str]], []] = Filter()

--- a/tutormfe/hooks.py
+++ b/tutormfe/hooks.py
@@ -10,17 +10,16 @@ import typing as t
 
 from tutor.core.hooks import Filter
 
-MFE_ATTRS_TYPE = t.Dict[
-    t.Literal["repository", "port", "version"], t.Union["str", int]
-]
-FRONTEND_TEMPLATE_SITE_ATTRS_TYPE = t.Dict[
-    t.Literal["repository", "version"], t.Union["str", int]
+MFE_ATTRS_TYPE = t.Dict[t.Literal["repository", "port", "version"], t.Union["str", int]]
+FRONTEND_APP_ATTRS_TYPE = t.Dict[
+    t.Literal["repository", "version", "site"], t.Union["str", int]
 ]
 
 MFE_APPS: Filter[dict[str, MFE_ATTRS_TYPE], []] = Filter()
 
-# TODO: This will hold the list of which apps are "enabled" so we can switch between mfe
-# and frontend-base ones
-FRONTEND_APPS: Filter[dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE], []] = Filter()
+# This holds which apps are enabled and if they will build from a custom repo
+FRONTEND_APPS: Filter[dict[str, FRONTEND_APP_ATTRS_TYPE], []] = Filter()
+# This holds all the possible frontend-sites which by default it's the internal one.
+FRONTEND_SITES: Filter[dict[str, FRONTEND_APP_ATTRS_TYPE], []] = Filter()
 
 PLUGIN_SLOTS: Filter[list[tuple[str, str, str]], []] = Filter()

--- a/tutormfe/hooks.py
+++ b/tutormfe/hooks.py
@@ -14,8 +14,8 @@ MFE_ATTRS_TYPE = t.Dict[t.Literal["repository", "port", "version"], t.Union["str
 
 # Extended MFE type that includes externalRoutes
 SITE_ATTRS_TYPE = t.Dict[
-    t.Literal["repository", "port", "version"],
-    t.Union[str, int],
+    t.Literal["repository", "port", "version", "siteConfig"],
+    t.Union[str, int, dict],
 ]
 
 FRONTEND_APP_ATTRS_TYPE = t.Dict[

--- a/tutormfe/hooks.py
+++ b/tutormfe/hooks.py
@@ -13,7 +13,7 @@ from tutor.core.hooks import Filter
 MFE_ATTRS_TYPE = t.Dict[t.Literal["repository", "port", "version"], t.Union["str", int]]
 
 # Extended MFE type that includes externalRoutes
-SITE_ATTRS_TYPE = t.Dict[
+FRONTEND_SITE_ATTRS_TYPE = t.Dict[
     t.Literal["repository", "port", "version", "siteConfig"],
     t.Union[str, int, dict],
 ]
@@ -28,7 +28,7 @@ MFE_APPS: Filter[dict[str, MFE_ATTRS_TYPE], []] = Filter()
 # This holds which apps are enabled and if they will build from a custom repo
 FRONTEND_APPS: Filter[dict[str, FRONTEND_APP_ATTRS_TYPE], []] = Filter()
 # This holds all the possible frontend-sites which by default it's the internal one.
-FRONTEND_SITES: Filter[dict[str, SITE_ATTRS_TYPE], []] = Filter()
+FRONTEND_SITES: Filter[dict[str, FRONTEND_SITE_ATTRS_TYPE], []] = Filter()
 
 PLUGIN_SLOTS: Filter[list[tuple[str, str, str]], []] = Filter()
 

--- a/tutormfe/hooks.py
+++ b/tutormfe/hooks.py
@@ -28,7 +28,7 @@ MFE_APPS: Filter[dict[str, MFE_ATTRS_TYPE], []] = Filter()
 # This holds which apps are enabled and if they will build from a custom repo
 FRONTEND_APPS: Filter[dict[str, FRONTEND_APP_ATTRS_TYPE], []] = Filter()
 # This holds all the possible frontend-sites which by default it's the internal one.
-FRONTEND_SITES: Filter[dict[str, FRONTEND_APP_ATTRS_TYPE], []] = Filter()
+FRONTEND_SITES: Filter[dict[str, SITE_ATTRS_TYPE], []] = Filter()
 
 PLUGIN_SLOTS: Filter[list[tuple[str, str, str]], []] = Filter()
 

--- a/tutormfe/hooks.py
+++ b/tutormfe/hooks.py
@@ -15,9 +15,7 @@ FRONTEND_TEMPLATE_SITE_ATTRS_TYPE = t.Dict[t.Literal["repository", "version"], t
 
 MFE_APPS: Filter[dict[str, MFE_ATTRS_TYPE], []] = Filter()
 
-# This will hold the frontent-template-site like repos (ideally one)
-FRONTEND_BASE_APPS: Filter[dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE], []] = Filter()
-# This will hold the list of which apps are "enabled" so we can switch between mfe and frontend-base ones
+# TODO: This will hold the list of which apps are "enabled" so we can switch between mfe and frontend-base ones
 FRONTEND_APPS: Filter[dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE], []] = Filter()
 
 PLUGIN_SLOTS: Filter[list[tuple[str, str, str]], []] = Filter()

--- a/tutormfe/hooks.py
+++ b/tutormfe/hooks.py
@@ -10,13 +10,17 @@ import typing as t
 
 from tutor.core.hooks import Filter
 
-MFE_ATTRS_TYPE = t.Dict[t.Literal["repository", "port", "version"], t.Union["str", int]]
-FRONTEND_TEMPLATE_SITE_ATTRS_TYPE = t.Dict
+MFE_ATTRS_TYPE = t.Dict[
+    t.Literal["repository", "port", "version"], t.Union["str", int]
+]
+FRONTEND_TEMPLATE_SITE_ATTRS_TYPE = t.Dict[
+    t.Literal["repository", "version"], t.Union["str", int]
+]
 
 MFE_APPS: Filter[dict[str, MFE_ATTRS_TYPE], []] = Filter()
 
 # TODO: This will hold the list of which apps are "enabled" so we can switch between mfe
 # and frontend-base ones
-FRONTEND_APPS: Filter[dict[str, t.Dict], []] = Filter()
+FRONTEND_APPS: Filter[dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE], []] = Filter()
 
 PLUGIN_SLOTS: Filter[list[tuple[str, str, str]], []] = Filter()

--- a/tutormfe/patches/local-docker-compose-dev-services
+++ b/tutormfe/patches/local-docker-compose-dev-services
@@ -26,7 +26,9 @@ mfe:
 {%- if MFE_HOST_EXTRA_FILES %}
        - 8002:8002
 {%- endif %}
+{# TODO: Add here the ports for unmounted site-configs #}
        {%- for app_name, app in mfe_data.unmounted %}
        - {{ app["port"] }}:8002 # {{ app_name }}
        {%- endfor %}
+       - 8080:8002
 {% endif %}

--- a/tutormfe/patches/mfe-dockerfile-pre-npm-install-template-site
+++ b/tutormfe/patches/mfe-dockerfile-pre-npm-install-template-site
@@ -1,3 +1,0 @@
-# Copy packs directory before npm install for template-site
-# This is needed because template-site has local file dependencies in its package.json
-COPY --from=template-site-src /packs /openedx/app/packs

--- a/tutormfe/patches/mfe-dockerfile-pre-npm-install-template-site
+++ b/tutormfe/patches/mfe-dockerfile-pre-npm-install-template-site
@@ -1,0 +1,3 @@
+# Copy packs directory before npm install for template-site
+# This is needed because template-site has local file dependencies in its package.json
+COPY --from=template-site-src /packs /openedx/app/packs

--- a/tutormfe/patches/openedx-lms-development-settings
+++ b/tutormfe/patches/openedx-lms-development-settings
@@ -87,6 +87,18 @@ MFE_CONFIG["ADMIN_CONSOLE_URL"] = ADMIN_CONSOLE_MICROFRONTEND_URL
 CATALOG_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ get_mfe("catalog")["port"] }}/catalog"
 {% endif %}
 
+{% if is_frontend_app("authn") %}
+{% set app = get_frontend_app("authn") %}
+{% set site = get_frontend_site(app.get("site", "default")) %}
+AUTHN_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ site["port"] }}/authn"
+{% endif %}
+
+{% if is_frontend_app("learner-dashboard") %}
+{% set app = get_frontend_app("learner-dashboard") %}
+{% set site = get_frontend_site(app.get("site", "default")) %}
+LEARNER_HOME_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ site["port"] }}/learner-dashboard"
+{% endif %}
+
 # Cors configuration
 {% for app_name, app in iter_mfes() %}
 # {{ app_name }} MFE

--- a/tutormfe/patches/openedx-lms-development-settings
+++ b/tutormfe/patches/openedx-lms-development-settings
@@ -83,6 +83,19 @@ ADMIN_CONSOLE_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ get_mfe("admin-conso
 MFE_CONFIG["ADMIN_CONSOLE_URL"] = ADMIN_CONSOLE_MICROFRONTEND_URL
 {% endif %}
 
+{% if is_frontend_app("authn") %}
+{% set app = get_frontend_app("authn") %}
+{% set site = get_frontend_site(app.get("site", "default")) %}
+AUTHN_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ site["port"] }}/authn"
+{% endif %}
+
+{% if is_frontend_app("learner-dashboard") %}
+{% set app = get_frontend_app("learner-dashboard") %}
+{% set site = get_frontend_site(app.get("site", "default")) %}
+LEARNER_HOME_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ site["port"] }}/learner-dashboard"
+{% endif %}
+
+
 # Cors configuration
 {% for app_name, app in iter_mfes() %}
 # {{ app_name }} MFE

--- a/tutormfe/patches/openedx-lms-development-settings
+++ b/tutormfe/patches/openedx-lms-development-settings
@@ -91,5 +91,11 @@ LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}:{{ app["port"] }}")
 CSRF_TRUSTED_ORIGINS.append("http://{{ MFE_HOST }}:{{ app["port"] }}")
 {% endfor %}
 
+{% for app_name, app in iter_frontend_sites() %}
+CORS_ORIGIN_WHITELIST.append("http://{{ MFE_HOST }}:{{ app["port"] }}")
+LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}:{{ app["port"] }}")
+CSRF_TRUSTED_ORIGINS.append("http://{{ MFE_HOST }}:{{ app["port"] }}")
+{% endfor %}
+
 {{ patch("mfe-lms-common-settings") }}
 {{ patch("mfe-lms-development-settings") }}

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -20,6 +20,7 @@ from .hooks import (
     FRONTEND_APPS,
     FRONTEND_APP_ATTRS_TYPE,
     PLUGIN_SLOTS,
+    FRONTEND_SLOTS,
     SITE_ATTRS_TYPE,
 )
 
@@ -182,6 +183,14 @@ def get_plugin_slots(mfe_name: str) -> list[tuple[str, str]]:
     return [i[-2:] for i in PLUGIN_SLOTS.iterate() if i[0] == mfe_name]
 
 
+@tutor_hooks.lru_cache
+def get_frontend_slots() -> list[tuple[str, str]]:
+    """
+    This function is cached for performance.
+    """
+    return FRONTEND_SLOTS.apply([])
+
+
 def iter_mfes() -> t.Iterable[tuple[str, MFE_ATTRS_TYPE]]:
     """
     Yield:
@@ -241,6 +250,15 @@ def iter_plugin_slots(mfe_name: str) -> t.Iterable[tuple[str, str]]:
     yield from get_plugin_slots(mfe_name)
 
 
+def iter_frontend_slots() -> t.Iterable[tuple[str, str]]:
+    """
+    Yield:
+
+        (slot_name, plugin_config)
+    """
+    yield from get_frontend_slots()
+
+
 def is_mfe_enabled(mfe_name: str) -> bool:
     return mfe_name in get_mfes()
 
@@ -266,6 +284,7 @@ tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
         ("iter_frontend_sites", iter_frontend_sites),
         ("get_frontend_sites", get_frontend_sites),
         ("iter_plugin_slots", iter_plugin_slots),
+        ("iter_frontend_slots", iter_frontend_slots),
         ("is_mfe_enabled", is_mfe_enabled),
         ("is_frontend_app", is_frontend_app),
         ("MFEMountData", MFEMountData),

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -115,17 +115,16 @@ def get_frontend_apps(apps_to_build: bool = False) -> dict[str, FRONTEND_TEMPLAT
     all_frontend_apps = FRONTEND_APPS.apply({})
 
     if not apps_to_build:
-        return {}
+        return all_frontend_apps
 
     # When returning apps to build we only return the ones that have a repository defined
     # (those are the ones to be built) and we prefix the name
     # with "frontend-app-" to avoid conflicts with MFE names
-    apps_to_return = {
+    return {
         f"frontend-app-{name}": attrs 
         for name, attrs in all_frontend_apps.items() 
         if "repository" in attrs
     }
-    return apps_to_return
 
 
 @tutor_hooks.lru_cache

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -13,7 +13,7 @@ from tutor.hooks import priorities
 from tutor.types import Config, get_typed
 
 from .__about__ import __version__
-from .hooks import MFE_APPS, MFE_ATTRS_TYPE, FRONTEND_BASE_APPS, FRONTEND_APPS, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE, PLUGIN_SLOTS
+from .hooks import MFE_APPS, MFE_ATTRS_TYPE, FRONTEND_APPS, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE, PLUGIN_SLOTS
 
 # Handle version suffix in main mode, just like tutor core
 if __version_suffix__:
@@ -78,8 +78,8 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
     },
     "template-site": {
         "repository": "https://github.com/WGU-Open-edX/frontend-template-site.git",
+        "version": "initial",
         "port": 8080,
-        "frontend_base_app": True,  # Mark this app as a frontend base app maybe (?)
     } 
 }
 

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -95,6 +95,7 @@ CORE_FRONTEND_SITES: dict[str, SITE_ATTRS_TYPE] = {
             "siteName": "Frontend Template Site",
             "accessTokenCookieName": "edx-jwt-cookie-header-payload",
             "redirectRoleId": "org.openedx.frontend.role.dashboard",
+            "frontendBaseVersion": "^1.0.0-alpha",
             "externalRoutes": [
                 {
                     "role": "org.openedx.frontend.role.profile",

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -5,7 +5,7 @@ import typing as t
 from glob import glob
 
 import importlib_resources
-from tutor import fmt, config as tutor_config
+from tutor import fmt
 from tutor import hooks as tutor_hooks
 from tutor.__about__ import __version_suffix__
 from tutor.bindmount import iter_mounts
@@ -20,6 +20,7 @@ from .hooks import (
     FRONTEND_APPS,
     FRONTEND_APP_ATTRS_TYPE,
     PLUGIN_SLOTS,
+    SITE_ATTRS_TYPE,
 )
 
 # Handle version suffix in main mode, just like tutor core
@@ -85,7 +86,7 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
     },
 }
 
-CORE_FRONTEND_SITES: dict[str, MFE_ATTRS_TYPE] = {
+CORE_FRONTEND_SITES: dict[str, SITE_ATTRS_TYPE] = {
     "default": {
         "repository": "local",
         "port": 8080,

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -5,7 +5,7 @@ import typing as t
 from glob import glob
 
 import importlib_resources
-from tutor import fmt
+from tutor import fmt, config as tutor_config
 from tutor import hooks as tutor_hooks
 from tutor.__about__ import __version_suffix__
 from tutor.bindmount import iter_mounts
@@ -13,7 +13,7 @@ from tutor.hooks import priorities
 from tutor.types import Config, get_typed
 
 from .__about__ import __version__
-from .hooks import MFE_APPS, MFE_ATTRS_TYPE, PLUGIN_SLOTS
+from .hooks import MFE_APPS, MFE_ATTRS_TYPE, FRONTEND_BASE_APPS, FRONTEND_APPS, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE, PLUGIN_SLOTS
 
 # Handle version suffix in main mode, just like tutor core
 if __version_suffix__:
@@ -95,6 +95,14 @@ def get_mfes() -> dict[str, MFE_ATTRS_TYPE]:
     return MFE_APPS.apply({})
 
 
+@tutor_hooks.lru_cache
+def get_frontend_apps() -> dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]:
+    """
+    This function is cached for performance.
+    """
+    return FRONTEND_APPS.apply({})
+
+
 class MFEMountData:
     """Stores categorized mounted and unmounted MFEs."""
 
@@ -129,6 +137,14 @@ def iter_mfes() -> t.Iterable[tuple[str, MFE_ATTRS_TYPE]]:
     """
     yield from get_mfes().items()
 
+def iter_frontent_apps() -> t.Iterable[tuple[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]:
+    """
+    Yield:
+
+        (name, dict)
+    """
+    yield from get_frontend_apps().items()
+
 
 def iter_plugin_slots(mfe_name: str) -> t.Iterable[tuple[str, str]]:
     """
@@ -142,6 +158,9 @@ def iter_plugin_slots(mfe_name: str) -> t.Iterable[tuple[str, str]]:
 def is_mfe_enabled(mfe_name: str) -> bool:
     return mfe_name in get_mfes()
 
+def is_frontend_app_enabled(app_name: str) -> bool:
+    return app_name in get_frontend_apps()
+
 
 def get_mfe(mfe_name: str) -> t.Union[MFE_ATTRS_TYPE, t.Any]:
     return get_mfes().get(mfe_name, {})
@@ -152,8 +171,10 @@ tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
     [
         ("get_mfe", get_mfe),
         ("iter_mfes", iter_mfes),
+        ("iter_frontend_apps", iter_frontent_apps),
         ("iter_plugin_slots", iter_plugin_slots),
         ("is_mfe_enabled", is_mfe_enabled),
+        ("is_frontend_app_enabled", is_frontend_app_enabled),
         ("MFEMountData", MFEMountData),
     ]
 )
@@ -217,6 +238,7 @@ with open(
     tutor_hooks.Filters.CLI_DO_INIT_TASKS.add_item(("lms", task_file.read()))
 
 REPO_PREFIX = "frontend-app-"
+FRONTEND_TEMPLATE_SITE_REPO = "frontend-template-site"
 
 
 @tutor_hooks.Filters.COMPOSE_MOUNTS.add()

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -142,13 +142,28 @@ def iter_mfes() -> t.Iterable[tuple[str, MFE_ATTRS_TYPE]]:
     """
     yield from get_mfes().items()
 
-def iter_frontent_apps() -> t.Iterable[tuple[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]:
+# Iter throgh all mfes and adds the unique frontend apps,
+# so we can have a list of all the things that are unique that needs
+# to be added to Caddyfile, for example instructor dashboard that was 
+# created as frontend-base app but didn't exist as a MFE before
+# so it returns the whole mfes list plus the unique frontend apps that are not in the mfe list
+def iter_frontend_apps() -> t.Iterable[tuple[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]:
     """
     Yield:
 
         (name, dict)
     """
-    yield from get_frontend_apps().items()
+    mfes = get_mfes()
+    frontend_apps = get_frontend_apps()
+    
+    # First yield all MFEs
+    for name, attrs in mfes.items():
+        yield (name, attrs)
+    
+    # Then yield frontend apps that are not already MFEs
+    for name, attrs in frontend_apps.items():
+        if name not in mfes:
+            yield (name, attrs)
 
 
 def iter_plugin_slots(mfe_name: str) -> t.Iterable[tuple[str, str]]:
@@ -176,7 +191,7 @@ tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
     [
         ("get_mfe", get_mfe),
         ("iter_mfes", iter_mfes),
-        ("iter_frontend_apps", iter_frontent_apps),
+        ("iter_frontend_apps", iter_frontend_apps),
         ("iter_plugin_slots", iter_plugin_slots),
         ("is_mfe_enabled", is_mfe_enabled),
         ("is_frontend_app_enabled", is_frontend_app_enabled),

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -13,7 +13,14 @@ from tutor.hooks import priorities
 from tutor.types import Config, get_typed
 
 from .__about__ import __version__
-from .hooks import MFE_APPS, MFE_ATTRS_TYPE, FRONTEND_APPS, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE, PLUGIN_SLOTS
+from .hooks import (
+    FRONTEND_SITES,
+    MFE_APPS,
+    MFE_ATTRS_TYPE,
+    FRONTEND_APPS,
+    FRONTEND_APP_ATTRS_TYPE,
+    PLUGIN_SLOTS,
+)
 
 # Handle version suffix in main mode, just like tutor core
 if __version_suffix__:
@@ -76,11 +83,13 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
         "repository": "https://github.com/openedx/frontend-app-profile.git",
         "port": 1995,
     },
-    # "template-site": {
-    #     "repository": "https://github.com/WGU-Open-edX/frontend-template-site.git",
-    #     "version": "initial",
-    #     "port": 8080,
-    # } 
+}
+
+CORE_FRONTEND_SITES: dict[str, MFE_ATTRS_TYPE] = {
+    "default": {
+        "repository": "local",
+        "port": 8080,
+    },
 }
 
 
@@ -90,6 +99,14 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
 def _add_core_mfe_apps(apps: dict[str, MFE_ATTRS_TYPE]) -> dict[str, MFE_ATTRS_TYPE]:
     apps.update(CORE_MFE_APPS)
     return apps
+
+
+@FRONTEND_SITES.add(priority=tutor_hooks.priorities.HIGH)
+def _add_core_frontend_sites(
+    sites: dict[str, MFE_ATTRS_TYPE],
+) -> dict[str, MFE_ATTRS_TYPE]:
+    sites.update(CORE_FRONTEND_SITES)
+    return sites
 
 
 @tutor_hooks.lru_cache
@@ -108,40 +125,20 @@ def get_mfes() -> dict[str, MFE_ATTRS_TYPE]:
 
 
 @tutor_hooks.lru_cache
-def get_frontend_apps(apps_to_build: bool = False) -> dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]:
+def get_frontend_apps() -> dict[str, FRONTEND_APP_ATTRS_TYPE]:
     """
     This function is cached for performance.
     """
-    all_frontend_apps = FRONTEND_APPS.apply({})
-
-    if not apps_to_build:
-        return all_frontend_apps
-
-    # When returning apps to build we only return the ones that have a repository defined
-    # (those are the ones to be built) and we prefix the name
-    # with "frontend-app-" to avoid conflicts with MFE names
-    return {
-        f"frontend-app-{name}": attrs 
-        for name, attrs in all_frontend_apps.items() 
-        if "repository" in attrs
-    }
+    return FRONTEND_APPS.apply({})
 
 
 @tutor_hooks.lru_cache
-def get_all_apps() -> dict[str, t.Union[MFE_ATTRS_TYPE, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]:
+def get_frontend_sites() -> dict[str, FRONTEND_APP_ATTRS_TYPE]:
     """
     This function is cached for performance.
     """
-    # IMPORTANT: Make a copy to avoid mutating the cached result from get_frontend_apps()
-    all_apps = get_frontend_apps(apps_to_build=True).copy()
-    mfes = get_mfes()
-    all_apps.update(mfes)
+    return FRONTEND_SITES.apply({})
 
-    # ensure frontend-template-site is the last one on the all_apps dict
-    if "template-site" in all_apps:
-        all_apps["template-site"] = all_apps.pop("template-site")
-
-    return all_apps
 
 class MFEMountData:
     """Stores categorized mounted and unmounted MFEs."""
@@ -177,12 +174,30 @@ def iter_mfes() -> t.Iterable[tuple[str, MFE_ATTRS_TYPE]]:
     """
     yield from get_mfes().items()
 
-# Iter throgh all mfes and adds the unique frontend apps,
-# so we can have a list of all the things that are unique that needs
-# to be added to Caddyfile, for example instructor dashboard that was 
-# created as frontend-base app but didn't exist as a MFE before
-# so it returns the whole mfes list plus the unique frontend apps that are not in the mfe list
-def iter_unique_apps() -> t.Iterable[tuple[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]:
+
+def iter_frontend_apps() -> t.Iterable[tuple[str, FRONTEND_APP_ATTRS_TYPE]]:
+    """
+    Yield:
+
+        (name, dict)
+    """
+    frontend_apps = get_frontend_apps()
+    for name, attrs in frontend_apps.items():
+        yield (name, attrs)
+
+
+def iter_frontend_sites() -> t.Iterable[tuple[str, FRONTEND_APP_ATTRS_TYPE]]:
+    """
+    Yield:
+
+        (name, dict)
+    """
+    frontend_sites = get_frontend_sites()
+    for name, attrs in frontend_sites.items():
+        yield (name, attrs)
+
+
+def iter_paths() -> t.Iterable[tuple[str, FRONTEND_APP_ATTRS_TYPE]]:
     """
     Yield:
 
@@ -190,36 +205,15 @@ def iter_unique_apps() -> t.Iterable[tuple[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYP
     """
     mfes = get_mfes()
     frontend_apps = get_frontend_apps()
-    
+
     # First yield all MFEs
     for name, attrs in mfes.items():
         yield (name, attrs)
-    
+
     # Then yield frontend apps that are not already MFEs
     for name, attrs in frontend_apps.items():
         if name not in mfes:
             yield (name, attrs)
-
-# Iters through all apps that will be built
-def iter_all_apps() -> t.Iterable[tuple[str, t.Union[MFE_ATTRS_TYPE, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]]:
-    """
-    Yield:
-
-        (name, dict)
-    """
-    all_apps = get_all_apps()
-    for name, attrs in all_apps.items():
-        yield (name, attrs)
-
-def iter_frontend_apps_to_build() -> t.Iterable[tuple[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]:
-    """
-    Yield:
-
-        (name, dict)
-    """
-    frontend_apps = get_frontend_apps(apps_to_build=True)
-    for name, attrs in frontend_apps.items():
-        yield (name, attrs)
 
 
 def iter_plugin_slots(mfe_name: str) -> t.Iterable[tuple[str, str]]:
@@ -234,11 +228,14 @@ def iter_plugin_slots(mfe_name: str) -> t.Iterable[tuple[str, str]]:
 def is_mfe_enabled(mfe_name: str) -> bool:
     return mfe_name in get_mfes()
 
-def is_frontend_app_enabled(app_name: str) -> bool:
+
+def is_frontend_app(app_name: str) -> bool:
     return app_name in get_frontend_apps()
+
 
 def is_frontend_app_to_build(app_name: str) -> bool:
     return app_name in get_frontend_apps(apps_to_build=True)
+
 
 def get_mfe(mfe_name: str) -> t.Union[MFE_ATTRS_TYPE, t.Any]:
     return get_mfes().get(mfe_name, {})
@@ -249,12 +246,12 @@ tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
     [
         ("get_mfe", get_mfe),
         ("iter_mfes", iter_mfes),
-        ("iter_unique_apps", iter_unique_apps),
-        ("iter_all_apps", iter_all_apps),
-        ("iter_frontend_apps_to_build", iter_frontend_apps_to_build),
+        ("iter_paths", iter_paths),
+        ("iter_frontend_apps", iter_frontend_apps),
+        ("iter_frontend_sites", iter_frontend_sites),
         ("iter_plugin_slots", iter_plugin_slots),
         ("is_mfe_enabled", is_mfe_enabled),
-        ("is_frontend_app_enabled", is_frontend_app_enabled),
+        ("is_frontend_app", is_frontend_app),
         ("is_frontend_app_to_build", is_frontend_app_to_build),
         ("MFEMountData", MFEMountData),
     ]
@@ -319,8 +316,8 @@ with open(
     tutor_hooks.Filters.CLI_DO_INIT_TASKS.add_item(("lms", task_file.read()))
 
 REPO_PREFIX = "frontend-app-"
-# TODO: for now leave this and then find better semantic namings
-FRONTEND_TEMPLATE_SITE_PREFIX = "frontend-"
+FRONTEND_SITE_PREFIX = "frontend-site-"
+# TODO: figure out the whole mount thing not only for sites but also for the possible apps under it
 
 
 @tutor_hooks.Filters.COMPOSE_MOUNTS.add()
@@ -333,12 +330,18 @@ def _mount_frontend_apps(
     in dev mode, because in production, all MFEs are built and hosted on the
     singular 'mfe' service container.
     """
-    if path_basename.startswith(REPO_PREFIX) or path_basename.startswith(FRONTEND_TEMPLATE_SITE_PREFIX):
+    if path_basename.startswith(REPO_PREFIX) or path_basename.startswith(
+        FRONTEND_SITE_PREFIX
+    ):
         # Assumption:
         # For each repo named frontend-app-APPNAME, there is an associated
         # docker-compose service named APPNAME. If this assumption is broken,
         # then Tutor will try to mount the repo in a service that doesn't exist.
-        app_name = path_basename[len(REPO_PREFIX) :] if path_basename.startswith(REPO_PREFIX) else path_basename[len(FRONTEND_TEMPLATE_SITE_PREFIX) :]
+        app_name = (
+            path_basename[len(REPO_PREFIX) :]
+            if path_basename.startswith(REPO_PREFIX)
+            else path_basename[len(FRONTEND_SITE_PREFIX) :]
+        )
         volumes += [(app_name, "/openedx/app")]
     return volumes
 
@@ -348,9 +351,15 @@ def _mount_frontend_apps_on_build(
     mounts: list[tuple[str, str]], host_path: str
 ) -> list[tuple[str, str]]:
     path_basename = os.path.basename(host_path)
-    if path_basename.startswith(REPO_PREFIX) or path_basename.startswith(FRONTEND_TEMPLATE_SITE_PREFIX):
+    if path_basename.startswith(REPO_PREFIX) or path_basename.startswith(
+        FRONTEND_SITE_PREFIX
+    ):
         # Bind-mount repo at build-time, both for prod and dev images
-        app_name = path_basename[len(REPO_PREFIX) :] if path_basename.startswith(REPO_PREFIX) else path_basename[len(FRONTEND_TEMPLATE_SITE_PREFIX) :]
+        app_name = (
+            path_basename[len(REPO_PREFIX) :]
+            if path_basename.startswith(REPO_PREFIX)
+            else path_basename[len(FRONTEND_SITE_PREFIX) :]
+        )
         mounts.append(("mfe", f"{app_name}-src"))
         mounts.append((f"{app_name}-dev", f"{app_name}-src"))
     return mounts

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -90,6 +90,26 @@ CORE_FRONTEND_SITES: dict[str, SITE_ATTRS_TYPE] = {
     "default": {
         "repository": "local",
         "port": 8080,
+        "siteConfig": {
+            "siteId": "tutor-frontend-site",
+            "siteName": "Frontend Template Site",
+            "accessTokenCookieName": "edx-jwt-cookie-header-payload",
+            "redirectRoleId": "org.openedx.frontend.role.dashboard",
+            "externalRoutes": [
+                {
+                    "role": "org.openedx.frontend.role.profile",
+                    "url": ":1995/profile/",
+                },
+                {
+                    "role": "org.openedx.frontend.role.account",
+                    "url": ":1997/account/",
+                },
+                {
+                    "role": "org.openedx.frontend.role.logout",
+                    "url": ":8000/logout",
+                },
+            ],
+        },
     },
 }
 
@@ -224,6 +244,9 @@ def is_mfe_enabled(mfe_name: str) -> bool:
 
 
 def is_frontend_app(app_name: str) -> bool:
+    """
+    Returns True if the given app_name corresponds to a configured frontend app.
+    """
     return app_name in get_frontend_apps()
 
 
@@ -239,6 +262,7 @@ tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
         ("iter_paths", iter_paths),
         ("iter_frontend_apps", iter_frontend_apps),
         ("iter_frontend_sites", iter_frontend_sites),
+        ("get_frontend_sites", get_frontend_sites),
         ("iter_plugin_slots", iter_plugin_slots),
         ("is_mfe_enabled", is_mfe_enabled),
         ("is_frontend_app", is_frontend_app),
@@ -305,8 +329,6 @@ with open(
     tutor_hooks.Filters.CLI_DO_INIT_TASKS.add_item(("lms", task_file.read()))
 
 REPO_PREFIX = "frontend-app-"
-FRONTEND_SITE_PREFIX = "frontend-site-"
-# TODO: figure out the whole mount thing not only for sites but also for the possible apps under it
 
 
 @tutor_hooks.Filters.COMPOSE_MOUNTS.add()
@@ -319,18 +341,12 @@ def _mount_frontend_apps(
     in dev mode, because in production, all MFEs are built and hosted on the
     singular 'mfe' service container.
     """
-    if path_basename.startswith(REPO_PREFIX) or path_basename.startswith(
-        FRONTEND_SITE_PREFIX
-    ):
+    if path_basename.startswith(REPO_PREFIX):
         # Assumption:
         # For each repo named frontend-app-APPNAME, there is an associated
         # docker-compose service named APPNAME. If this assumption is broken,
         # then Tutor will try to mount the repo in a service that doesn't exist.
-        app_name = (
-            path_basename[len(REPO_PREFIX) :]
-            if path_basename.startswith(REPO_PREFIX)
-            else path_basename[len(FRONTEND_SITE_PREFIX) :]
-        )
+        app_name = path_basename[len(REPO_PREFIX) :]
         volumes += [(app_name, "/openedx/app")]
     return volumes
 
@@ -340,15 +356,9 @@ def _mount_frontend_apps_on_build(
     mounts: list[tuple[str, str]], host_path: str
 ) -> list[tuple[str, str]]:
     path_basename = os.path.basename(host_path)
-    if path_basename.startswith(REPO_PREFIX) or path_basename.startswith(
-        FRONTEND_SITE_PREFIX
-    ):
+    if path_basename.startswith(REPO_PREFIX):
         # Bind-mount repo at build-time, both for prod and dev images
-        app_name = (
-            path_basename[len(REPO_PREFIX) :]
-            if path_basename.startswith(REPO_PREFIX)
-            else path_basename[len(FRONTEND_SITE_PREFIX) :]
-        )
+        app_name = path_basename[len(REPO_PREFIX) :]
         mounts.append(("mfe", f"{app_name}-src"))
         mounts.append((f"{app_name}-dev", f"{app_name}-src"))
     return mounts

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -113,14 +113,18 @@ def get_frontend_apps(apps_to_build: bool = False) -> dict[str, FRONTEND_TEMPLAT
     This function is cached for performance.
     """
     all_frontend_apps = FRONTEND_APPS.apply({})
-    parsed_apps: dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE] = {}
-    for name, attrs in all_frontend_apps.items():
-        parsed_apps[f"frontend-app-{name}"] = attrs
+
     if not apps_to_build:
-        return parsed_apps
-    
-    apps_to_return = {name: attrs for name, attrs in parsed_apps.items() if "repository" in attrs}
-    # If apps_to_build is True, then we only want to return the frontend apps that have a repository
+        return {}
+
+    # When returning apps to build we only return the ones that have a repository defined
+    # (those are the ones to be built) and we prefix the name
+    # with "frontend-app-" to avoid conflicts with MFE names
+    apps_to_return = {
+        f"frontend-app-{name}": attrs 
+        for name, attrs in all_frontend_apps.items() 
+        if "repository" in attrs
+    }
     return apps_to_return
 
 
@@ -133,7 +137,7 @@ def get_all_apps() -> dict[str, t.Union[MFE_ATTRS_TYPE, FRONTEND_TEMPLATE_SITE_A
     all_apps = get_frontend_apps(apps_to_build=True).copy()
     mfes = get_mfes()
     all_apps.update(mfes)
-    
+
     # ensure frontend-template-site is the last one on the all_apps dict
     if "template-site" in all_apps:
         all_apps["template-site"] = all_apps.pop("template-site")

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -21,7 +21,7 @@ from .hooks import (
     FRONTEND_APP_ATTRS_TYPE,
     PLUGIN_SLOTS,
     FRONTEND_SLOTS,
-    SITE_ATTRS_TYPE,
+    FRONTEND_SITE_ATTRS_TYPE,
 )
 
 # Handle version suffix in main mode, just like tutor core
@@ -91,7 +91,7 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
     },
 }
 
-CORE_FRONTEND_SITES: dict[str, SITE_ATTRS_TYPE] = {
+CORE_FRONTEND_SITES: dict[str, FRONTEND_SITE_ATTRS_TYPE] = {
     "default": {
         "repository": "local",
         "port": 8080,
@@ -131,8 +131,8 @@ def _add_core_mfe_apps(apps: dict[str, MFE_ATTRS_TYPE]) -> dict[str, MFE_ATTRS_T
 
 @FRONTEND_SITES.add(priority=tutor_hooks.priorities.HIGH)
 def _add_core_frontend_sites(
-    sites: dict[str, MFE_ATTRS_TYPE],
-) -> dict[str, MFE_ATTRS_TYPE]:
+    sites: dict[str, FRONTEND_SITE_ATTRS_TYPE],
+) -> dict[str, FRONTEND_SITE_ATTRS_TYPE]:
     sites.update(CORE_FRONTEND_SITES)
     return sites
 
@@ -154,7 +154,7 @@ def get_frontend_apps() -> dict[str, FRONTEND_APP_ATTRS_TYPE]:
 
 
 @tutor_hooks.lru_cache
-def get_frontend_sites() -> dict[str, FRONTEND_APP_ATTRS_TYPE]:
+def get_frontend_sites() -> dict[str, FRONTEND_SITE_ATTRS_TYPE]:
     """
     This function is cached for performance.
     """
@@ -215,7 +215,7 @@ def iter_frontend_apps() -> t.Iterable[tuple[str, FRONTEND_APP_ATTRS_TYPE]]:
         yield (name, attrs)
 
 
-def iter_frontend_sites() -> t.Iterable[tuple[str, FRONTEND_APP_ATTRS_TYPE]]:
+def iter_frontend_sites() -> t.Iterable[tuple[str, FRONTEND_SITE_ATTRS_TYPE]]:
     """
     Yield:
 
@@ -278,7 +278,7 @@ def get_mfe(mfe_name: str) -> t.Union[MFE_ATTRS_TYPE, t.Any]:
     return get_mfes().get(mfe_name, {})
 
 
-def get_frontend_site(site_name: str) -> t.Union[SITE_ATTRS_TYPE, t.Any]:
+def get_frontend_site(site_name: str) -> t.Union[FRONTEND_SITE_ATTRS_TYPE, t.Any]:
     """
     Returns the attributes of a configured frontend site.
     """

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -151,11 +151,30 @@ def get_mfe(mfe_name: str) -> t.Union[MFE_ATTRS_TYPE, t.Any]:
     return get_mfes().get(mfe_name, {})
 
 
+def get_frontend_site(site_name: str) -> t.Union[SITE_ATTRS_TYPE, t.Any]:
+    """
+    Returns the attributes of a configured frontend site.
+    """
+    return get_frontend_sites().get(site_name, {})
+
+
+def get_frontend_app(app_name: str) -> t.Union[FRONTEND_APP_ATTRS_TYPE, t.Any]:
+    """
+    Returns the attributes of a configured frontend app.
+    """
+    return get_frontend_apps().get(app_name, {})
+
+
 # Make the mfe functions available within templates
 tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
     [
         ("get_mfe", get_mfe),
         ("iter_mfes", iter_mfes),
+        ("iter_paths", iter_paths),
+        ("iter_frontend_apps", iter_frontend_apps),
+        ("iter_frontend_sites", iter_frontend_sites),
+        ("get_frontend_site", get_frontend_site),
+        ("get_frontend_app", get_frontend_app),
         ("iter_plugin_slots", iter_plugin_slots),
         ("is_mfe_enabled", is_mfe_enabled),
         ("MFEMountData", MFEMountData),

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -76,11 +76,11 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
         "repository": "https://github.com/openedx/frontend-app-profile.git",
         "port": 1995,
     },
-    "template-site": {
-        "repository": "https://github.com/WGU-Open-edX/frontend-template-site.git",
-        "version": "initial",
-        "port": 8080,
-    } 
+    # "template-site": {
+    #     "repository": "https://github.com/WGU-Open-edX/frontend-template-site.git",
+    #     "version": "initial",
+    #     "port": 8080,
+    # } 
 }
 
 
@@ -100,13 +100,45 @@ def get_mfes() -> dict[str, MFE_ATTRS_TYPE]:
     return MFE_APPS.apply({})
 
 
+# List will need
+## Apps that are only frontend-apps
+## Apps that are only MFEs
+## Apps with unique ones (all old mfes + instruct)
+## 1 and 2 with 1 having something like a different identifier
+
+
 @tutor_hooks.lru_cache
-def get_frontend_apps() -> dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]:
+def get_frontend_apps(apps_to_build: bool = False) -> dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]:
     """
     This function is cached for performance.
     """
-    return FRONTEND_APPS.apply({})
+    all_frontend_apps = FRONTEND_APPS.apply({})
+    parsed_apps: dict[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE] = {}
+    for name, attrs in all_frontend_apps.items():
+        parsed_apps[f"frontend-app-{name}"] = attrs
+    if not apps_to_build:
+        return parsed_apps
+    
+    apps_to_return = {name: attrs for name, attrs in parsed_apps.items() if "repository" in attrs}
+    # If apps_to_build is True, then we only want to return the frontend apps that have a repository
+    return apps_to_return
 
+
+@tutor_hooks.lru_cache
+def get_all_apps() -> dict[str, t.Union[MFE_ATTRS_TYPE, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]:
+    """
+    This function is cached for performance.
+    """
+    # IMPORTANT: Make a copy to avoid mutating the cached result from get_frontend_apps()
+    all_apps = get_frontend_apps(apps_to_build=True).copy()
+    mfes = get_mfes()
+    all_apps.update(mfes)
+    
+    # ensure frontend-template-site is the last one on the all_apps dict
+    if "template-site" in all_apps:
+        all_apps["template-site"] = all_apps.pop("template-site")
+
+    return all_apps
 
 class MFEMountData:
     """Stores categorized mounted and unmounted MFEs."""
@@ -147,7 +179,7 @@ def iter_mfes() -> t.Iterable[tuple[str, MFE_ATTRS_TYPE]]:
 # to be added to Caddyfile, for example instructor dashboard that was 
 # created as frontend-base app but didn't exist as a MFE before
 # so it returns the whole mfes list plus the unique frontend apps that are not in the mfe list
-def iter_frontend_apps() -> t.Iterable[tuple[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]:
+def iter_unique_apps() -> t.Iterable[tuple[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]:
     """
     Yield:
 
@@ -165,6 +197,27 @@ def iter_frontend_apps() -> t.Iterable[tuple[str, FRONTEND_TEMPLATE_SITE_ATTRS_T
         if name not in mfes:
             yield (name, attrs)
 
+# Iters through all apps that will be built
+def iter_all_apps() -> t.Iterable[tuple[str, t.Union[MFE_ATTRS_TYPE, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]]:
+    """
+    Yield:
+
+        (name, dict)
+    """
+    all_apps = get_all_apps()
+    for name, attrs in all_apps.items():
+        yield (name, attrs)
+
+def iter_frontend_apps_to_build() -> t.Iterable[tuple[str, FRONTEND_TEMPLATE_SITE_ATTRS_TYPE]]:
+    """
+    Yield:
+
+        (name, dict)
+    """
+    frontend_apps = get_frontend_apps(apps_to_build=True)
+    for name, attrs in frontend_apps.items():
+        yield (name, attrs)
+
 
 def iter_plugin_slots(mfe_name: str) -> t.Iterable[tuple[str, str]]:
     """
@@ -181,6 +234,8 @@ def is_mfe_enabled(mfe_name: str) -> bool:
 def is_frontend_app_enabled(app_name: str) -> bool:
     return app_name in get_frontend_apps()
 
+def is_frontend_app_to_build(app_name: str) -> bool:
+    return app_name in get_frontend_apps(apps_to_build=True)
 
 def get_mfe(mfe_name: str) -> t.Union[MFE_ATTRS_TYPE, t.Any]:
     return get_mfes().get(mfe_name, {})
@@ -191,10 +246,13 @@ tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
     [
         ("get_mfe", get_mfe),
         ("iter_mfes", iter_mfes),
-        ("iter_frontend_apps", iter_frontend_apps),
+        ("iter_unique_apps", iter_unique_apps),
+        ("iter_all_apps", iter_all_apps),
+        ("iter_frontend_apps_to_build", iter_frontend_apps_to_build),
         ("iter_plugin_slots", iter_plugin_slots),
         ("is_mfe_enabled", is_mfe_enabled),
         ("is_frontend_app_enabled", is_frontend_app_enabled),
+        ("is_frontend_app_to_build", is_frontend_app_to_build),
         ("MFEMountData", MFEMountData),
     ]
 )

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -274,6 +274,20 @@ def get_mfe(mfe_name: str) -> t.Union[MFE_ATTRS_TYPE, t.Any]:
     return get_mfes().get(mfe_name, {})
 
 
+def get_frontend_site(site_name: str) -> t.Union[SITE_ATTRS_TYPE, t.Any]:
+    """
+    Returns the attributes of a configured frontend site.
+    """
+    return get_frontend_sites().get(site_name, {})
+
+
+def get_frontend_app(app_name: str) -> t.Union[FRONTEND_APP_ATTRS_TYPE, t.Any]:
+    """
+    Returns the attributes of a configured frontend app.
+    """
+    return get_frontend_apps().get(app_name, {})
+
+
 # Make the mfe functions available within templates
 tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
     [
@@ -282,7 +296,8 @@ tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
         ("iter_paths", iter_paths),
         ("iter_frontend_apps", iter_frontend_apps),
         ("iter_frontend_sites", iter_frontend_sites),
-        ("get_frontend_sites", get_frontend_sites),
+        ("get_frontend_site", get_frontend_site),
+        ("get_frontend_app", get_frontend_app),
         ("iter_plugin_slots", iter_plugin_slots),
         ("iter_frontend_slots", iter_frontend_slots),
         ("is_mfe_enabled", is_mfe_enabled),

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -96,6 +96,7 @@ CORE_FRONTEND_SITES: dict[str, SITE_ATTRS_TYPE] = {
             "accessTokenCookieName": "edx-jwt-cookie-header-payload",
             "redirectRoleId": "org.openedx.frontend.role.dashboard",
             "frontendBaseVersion": "^1.0.0-alpha",
+            "paragonVersion": "^23",
             "externalRoutes": [
                 {
                     "role": "org.openedx.frontend.role.profile",

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -117,13 +117,6 @@ def get_mfes() -> dict[str, MFE_ATTRS_TYPE]:
     return MFE_APPS.apply({})
 
 
-# List will need
-## Apps that are only frontend-apps
-## Apps that are only MFEs
-## Apps with unique ones (all old mfes + instruct)
-## 1 and 2 with 1 having something like a different identifier
-
-
 @tutor_hooks.lru_cache
 def get_frontend_apps() -> dict[str, FRONTEND_APP_ATTRS_TYPE]:
     """
@@ -233,10 +226,6 @@ def is_frontend_app(app_name: str) -> bool:
     return app_name in get_frontend_apps()
 
 
-def is_frontend_app_to_build(app_name: str) -> bool:
-    return app_name in get_frontend_apps(apps_to_build=True)
-
-
 def get_mfe(mfe_name: str) -> t.Union[MFE_ATTRS_TYPE, t.Any]:
     return get_mfes().get(mfe_name, {})
 
@@ -252,7 +241,6 @@ tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
         ("iter_plugin_slots", iter_plugin_slots),
         ("is_mfe_enabled", is_mfe_enabled),
         ("is_frontend_app", is_frontend_app),
-        ("is_frontend_app_to_build", is_frontend_app_to_build),
         ("MFEMountData", MFEMountData),
     ]
 )

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -76,6 +76,11 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
         "repository": "https://github.com/openedx/frontend-app-profile.git",
         "port": 1995,
     },
+    "template-site": {
+        "repository": "https://github.com/WGU-Open-edX/frontend-template-site.git",
+        "port": 8080,
+        "frontend_base_app": True,  # Mark this app as a frontend base app maybe (?)
+    } 
 }
 
 
@@ -238,7 +243,8 @@ with open(
     tutor_hooks.Filters.CLI_DO_INIT_TASKS.add_item(("lms", task_file.read()))
 
 REPO_PREFIX = "frontend-app-"
-FRONTEND_TEMPLATE_SITE_REPO = "frontend-template-site"
+# TODO: for now leave this and then find better semantic namings
+FRONTEND_TEMPLATE_SITE_PREFIX = "frontend-"
 
 
 @tutor_hooks.Filters.COMPOSE_MOUNTS.add()
@@ -251,12 +257,12 @@ def _mount_frontend_apps(
     in dev mode, because in production, all MFEs are built and hosted on the
     singular 'mfe' service container.
     """
-    if path_basename.startswith(REPO_PREFIX):
+    if path_basename.startswith(REPO_PREFIX) or path_basename.startswith(FRONTEND_TEMPLATE_SITE_PREFIX):
         # Assumption:
         # For each repo named frontend-app-APPNAME, there is an associated
         # docker-compose service named APPNAME. If this assumption is broken,
         # then Tutor will try to mount the repo in a service that doesn't exist.
-        app_name = path_basename[len(REPO_PREFIX) :]
+        app_name = path_basename[len(REPO_PREFIX) :] if path_basename.startswith(REPO_PREFIX) else path_basename[len(FRONTEND_TEMPLATE_SITE_PREFIX) :]
         volumes += [(app_name, "/openedx/app")]
     return volumes
 
@@ -266,9 +272,9 @@ def _mount_frontend_apps_on_build(
     mounts: list[tuple[str, str]], host_path: str
 ) -> list[tuple[str, str]]:
     path_basename = os.path.basename(host_path)
-    if path_basename.startswith(REPO_PREFIX):
+    if path_basename.startswith(REPO_PREFIX) or path_basename.startswith(FRONTEND_TEMPLATE_SITE_PREFIX):
         # Bind-mount repo at build-time, both for prod and dev images
-        app_name = path_basename[len(REPO_PREFIX) :]
+        app_name = path_basename[len(REPO_PREFIX) :] if path_basename.startswith(REPO_PREFIX) else path_basename[len(FRONTEND_TEMPLATE_SITE_PREFIX) :]
         mounts.append(("mfe", f"{app_name}-src"))
         mounts.append((f"{app_name}-dev", f"{app_name}-src"))
     return mounts

--- a/tutormfe/templates/mfe/apps/mfe/Caddyfile
+++ b/tutormfe/templates/mfe/apps/mfe/Caddyfile
@@ -52,13 +52,13 @@
     {%- endif %}
     {% endfor %}
 
-    {% for app_name, app in iter_frontend_sites() %}
-    @site_{{ app_name }} {
-        path /site-{{ app_name }} /site-{{ app_name }}/*
+    {% for site_name, app in iter_frontend_sites() %}
+    @site_{{ site_name }} {
+        path /site-{{ site_name }} /site-{{ site_name }}/*
     }
-    handle @site_{{ app_name }} {
-        uri strip_prefix /site-{{ app_name }}
-        root * /openedx/dist/site-{{ app_name }}
+    handle @site_{{ site_name }} {
+        uri strip_prefix /site-{{ site_name }}
+        root * /openedx/dist/site-{{ site_name }}
         # no index.html because we want to focus on assets in these ones
         try_files /{path}
         file_server

--- a/tutormfe/templates/mfe/apps/mfe/Caddyfile
+++ b/tutormfe/templates/mfe/apps/mfe/Caddyfile
@@ -51,7 +51,8 @@
     handle @site_{{ app_name }} {
         uri strip_prefix /site-{{ app_name }}
         root * /openedx/dist/site-{{ app_name }}
-        try_files /{path} /index.html
+        # no index.html because we want to focus on assets in these ones
+        try_files /{path}
         file_server
     }
     {% endfor %}

--- a/tutormfe/templates/mfe/apps/mfe/Caddyfile
+++ b/tutormfe/templates/mfe/apps/mfe/Caddyfile
@@ -1,6 +1,3 @@
-{
-    debug
-}
 :8002 {
     log {
         output stdout

--- a/tutormfe/templates/mfe/apps/mfe/Caddyfile
+++ b/tutormfe/templates/mfe/apps/mfe/Caddyfile
@@ -1,3 +1,6 @@
+{
+    debug
+}
 :8002 {
     log {
         output stdout
@@ -27,6 +30,7 @@
     {% endif %}
 
     {% for app_name, app in iter_mfes() %}
+    {% if app_name != "template-site" %}
     @mfe_{{ app_name }} {
         path /{{ app_name }} /{{ app_name }}/*
     }
@@ -34,7 +38,7 @@
         uri strip_prefix /{{ app_name }}
         {%- if is_frontend_app_enabled(app_name) %}
         # {{ app_name }} - using frontend-apps approach
-        root * /openedx/dist/frontend-template-site
+        root * /openedx/dist/template-site
         {%- else %}
         # {{ app_name }} - using traditional MFE approach
         root * /openedx/dist/{{ app_name }}
@@ -42,5 +46,17 @@
         try_files /{path} /index.html
         file_server
     }
+    {# TODO: Temporal while better rules are in place #}
+    {% else %}
+    @mfe_{{ app_name }} {
+        path / /*
+    }
+    handle @mfe_{{ app_name }} {
+        root * /openedx/dist/template-site
+        try_files /{path} /index.html
+        file_server
+    }
+    {% endif %}
+
     {% endfor %}
 }

--- a/tutormfe/templates/mfe/apps/mfe/Caddyfile
+++ b/tutormfe/templates/mfe/apps/mfe/Caddyfile
@@ -26,15 +26,15 @@
     redir @authoring /authoring/{re.authoring.1} permanent
     {% endif %}
 
-    {% for app_name, app in iter_unique_apps() %}
+    {% for app_name, app in iter_paths() %}
     @mfe_{{ app_name }} {
         path /{{ app_name }} /{{ app_name }}/*
     }
     handle @mfe_{{ app_name }} {
         uri strip_prefix /{{ app_name }}
-        {%- if is_frontend_app_enabled(app_name) %}
+        {%- if is_frontend_app(app_name) %}
         # {{ app_name }} - using frontend-apps approach
-        root * /openedx/dist/template-site
+        root * /openedx/dist/site-{{ app.get("site", "default") }}
         {%- else %}
         # {{ app_name }} - using traditional MFE approach
         root * /openedx/dist/{{ app_name }}
@@ -42,6 +42,17 @@
         try_files /{path} /index.html
         file_server
     }
+    {% endfor %}
 
+    {% for app_name, app in iter_frontend_sites() %}
+    @site_{{ app_name }} {
+        path /site-{{ app_name }} /site-{{ app_name }}/*
+    }
+    handle @site_{{ app_name }} {
+        uri strip_prefix /site-{{ app_name }}
+        root * /openedx/dist/site-{{ app_name }}
+        try_files /{path} /index.html
+        file_server
+    }
     {% endfor %}
 }

--- a/tutormfe/templates/mfe/apps/mfe/Caddyfile
+++ b/tutormfe/templates/mfe/apps/mfe/Caddyfile
@@ -32,7 +32,13 @@
     }
     handle @mfe_{{ app_name }} {
         uri strip_prefix /{{ app_name }}
+        {%- if is_frontend_app_enabled(app_name) %}
+        # {{ app_name }} - using frontend-apps approach
+        root * /openedx/dist/frontend-template-site
+        {%- else %}
+        # {{ app_name }} - using traditional MFE approach
         root * /openedx/dist/{{ app_name }}
+        {%- endif %}
         try_files /{path} /index.html
         file_server
     }

--- a/tutormfe/templates/mfe/apps/mfe/Caddyfile
+++ b/tutormfe/templates/mfe/apps/mfe/Caddyfile
@@ -26,7 +26,7 @@
     redir @authoring /authoring/{re.authoring.1} permanent
     {% endif %}
 
-    {% for app_name, app in iter_frontend_apps() %}
+    {% for app_name, app in iter_unique_apps() %}
     @mfe_{{ app_name }} {
         path /{{ app_name }} /{{ app_name }}/*
     }

--- a/tutormfe/templates/mfe/apps/mfe/Caddyfile
+++ b/tutormfe/templates/mfe/apps/mfe/Caddyfile
@@ -29,7 +29,7 @@
     redir @authoring /authoring/{re.authoring.1} permanent
     {% endif %}
 
-    {% for app_name, app in iter_mfes() %}
+    {% for app_name, app in iter_frontend_apps() %}
     @mfe_{{ app_name }} {
         path /{{ app_name }} /{{ app_name }}/*
     }

--- a/tutormfe/templates/mfe/apps/mfe/Caddyfile
+++ b/tutormfe/templates/mfe/apps/mfe/Caddyfile
@@ -30,7 +30,6 @@
     {% endif %}
 
     {% for app_name, app in iter_mfes() %}
-    {% if app_name != "template-site" %}
     @mfe_{{ app_name }} {
         path /{{ app_name }} /{{ app_name }}/*
     }
@@ -46,17 +45,6 @@
         try_files /{path} /index.html
         file_server
     }
-    {# TODO: Temporal while better rules are in place #}
-    {% else %}
-    @mfe_{{ app_name }} {
-        path / /*
-    }
-    handle @mfe_{{ app_name }} {
-        root * /openedx/dist/template-site
-        try_files /{path} /index.html
-        file_server
-    }
-    {% endif %}
 
     {% endfor %}
 }

--- a/tutormfe/templates/mfe/apps/mfe/Caddyfile
+++ b/tutormfe/templates/mfe/apps/mfe/Caddyfile
@@ -27,21 +27,29 @@
     {% endif %}
 
     {% for app_name, app in iter_paths() %}
+
+    {%- if is_frontend_app(app_name) %}
+    @app_{{ app_name }} {
+        path /{{ app_name }} /{{ app_name }}/*
+    }
+    handle @app_{{ app_name }} {
+        uri strip_prefix /{{ app_name }}
+        root * /openedx/dist/site-{{ app.get("site", "default") }}
+        try_files /{path} /index.html
+        file_server
+    }
+    {%- else %}
+
     @mfe_{{ app_name }} {
         path /{{ app_name }} /{{ app_name }}/*
     }
     handle @mfe_{{ app_name }} {
         uri strip_prefix /{{ app_name }}
-        {%- if is_frontend_app(app_name) %}
-        # {{ app_name }} - using frontend-apps approach
-        root * /openedx/dist/site-{{ app.get("site", "default") }}
-        {%- else %}
-        # {{ app_name }} - using traditional MFE approach
         root * /openedx/dist/{{ app_name }}
-        {%- endif %}
         try_files /{path} /index.html
         file_server
     }
+    {%- endif %}
     {% endfor %}
 
     {% for app_name, app in iter_frontend_sites() %}

--- a/tutormfe/templates/mfe/apps/mfe/Caddyfile
+++ b/tutormfe/templates/mfe/apps/mfe/Caddyfile
@@ -52,6 +52,10 @@
     {%- endif %}
     {% endfor %}
 
+    # Handle frontend sites, which are meant to serve only static assets, without an index.html.
+    # When fetched from the proper url handle they'll be returned with a index.html,
+    # but if someone tries to access them directly (like the chunk links or general assets)
+    # they'll get the files directy from this block
     {% for site_name, app in iter_frontend_sites() %}
     @site_{{ site_name }} {
         path /site-{{ site_name }} /site-{{ site_name }}/*

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -83,51 +83,47 @@ RUN npm run build
 {% endfor %}
 
 
-{%- for site_name, app in iter_frontend_sites() %}
+{%- for site_name, site in iter_frontend_sites() %}
 ######## build of site-{{ site_name }}-git
 FROM base AS site-{{ site_name }}-git
 WORKDIR /openedx/site
 
 # Either use site-local or the configured repository
-{%- if app.get("repository") and app["repository"] == "local" %}
+{%- if site.get("repository") and site["repository"] == "local" %}
 COPY frontend-site/ /openedx/site
 {%- else %}
-ADD --keep-git-dir=true {{ app["repository"] }}#{{ app.get("version", MFE_COMMON_VERSION) }} .
+ADD --keep-git-dir=true {{ site["repository"] }}#{{ site.get("version", MFE_COMMON_VERSION) }} .
 {%- endif %}
 {%- endfor %}
 
 
 {%- set ns = namespace(repos_exists=0) %}
-{% for site_name, app in iter_frontend_sites() %}
+{% for site_name, site in iter_frontend_sites() %}
 ######## build of site-{{ site_name }}-src
 FROM base AS site-{{ site_name }}-src
-WORKDIR /openedx/site/packages
 
+{%- if site.get("repository") and site["repository"] == "local" %}
 # Git clone all frontend apps that should be built
-
+WORKDIR /openedx/site/packages
 {%- for app_name, app in iter_frontend_apps() %}
 {%- if app.get("repository") %}
 RUN git clone --depth 1 --branch {{ app.get("version", MFE_COMMON_VERSION) }} {{ app["repository"] }} frontend-app-{{ app_name }}
 {%- set ns.repos_exists = 1 %}
 {%- endif %}
 {%- endfor %}
-
+{%- endif %}
 WORKDIR /openedx/site
 
 COPY --from=site-{{ site_name }}-git /openedx/site/package.json /openedx/site
 
 ARG NPM_REGISTRY={{ NPM_REGISTRY }}
 {{ patch("frontend-site-dockerfile-pre-npm-install") }}
-
-{# This one we need to optimize, so the copy doesn't trigger a new npm install when it's not required #}
 RUN --mount=type=cache,target=/root/.npm-sites,sharing=shared npm install --no-audit --no-fund --registry=$NPM_REGISTRY
-
 {{ patch("frontend-site-dockerfile-post-npm-install") }}
-
 {%- endfor %}
 
 
-{%- for site_name, app in iter_frontend_sites() %}
+{%- for site_name, site in iter_frontend_sites() %}
 ######## build of site-{{ site_name }}-common
 FROM base AS site-{{ site_name }}-common
 WORKDIR /openedx/site
@@ -140,7 +136,7 @@ RUN npm run build:packages
 {%- endif %}
 
 {{ patch("frontend-site-dockerfile-pre-npm-build") }}
-RUN PUBLIC_PATH="/site-{{ app.get("site", "default") }}/" npm run build
+RUN PUBLIC_PATH="/site-{{ site.get("site", "default") }}/" npm run build
 {{ patch("frontend-site-dockerfile-post-npm-build") }}
 
 {%- endfor %}
@@ -156,7 +152,7 @@ RUN mkdir -p /openedx/dist
 COPY --from={{ app_name }}-prod /openedx/app/dist /openedx/dist/{{ app_name }}
 {% endfor %}
 
-{% for site_name, app in iter_frontend_sites() %}
+{%- for site_name, site in iter_frontend_sites() %}
 COPY --from=site-{{ site_name }}-common /openedx/site/dist /openedx/dist/site-{{ site_name }}
 {% endfor %}
 

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -50,6 +50,10 @@ RUN --mount=type=cache,target=/root/.npm,sharing=shared npm clean-install --no-a
 {{ patch("mfe-dockerfile-post-npm-install-{}".format(app_name)) }}
 COPY --from={{ app_name }}-src / /openedx/app
 
+RUN make OPENEDX_ATLAS_PULL=true ATLAS_OPTIONS="--repository={{ ATLAS_REPOSITORY }} --revision={{ ATLAS_REVISION }} {{ ATLAS_OPTIONS }}" pull_translations
+
+EXPOSE {{ app['port'] }}
+
 # Configuration needed at build time
 ENV APP_ID={{ app_name }}
 ENV PUBLIC_PATH='/{{ app_name }}/'
@@ -62,8 +66,6 @@ COPY env.config.jsx /openedx/app
 {{ patch("mfe-dockerfile-pre-npm-build") }}
 {{ patch("mfe-dockerfile-pre-npm-build-{}".format(app_name)) }}
 
-EXPOSE {{ app['port'] }}
-
 ######## {{ app_name }} (dev)
 FROM {{ app_name }}-common AS {{ app_name }}-dev
 ENV NODE_ENV=development
@@ -74,7 +76,6 @@ CMD ["/bin/bash", "-c", "npm run start --- --config ./webpack.dev-tutor.config.j
 {%- for app_name, app in iter_mfes() %}
 ######## {{ app_name }} (production)
 FROM {{ app_name }}-common AS {{ app_name }}-prod
-
 ENV NODE_ENV=production
 RUN npm run build
 {{ patch("mfe-dockerfile-post-npm-build") }}

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -96,7 +96,6 @@ RUN git clone --depth 1 --branch {{ app.get("version", MFE_COMMON_VERSION) }} {{
 
 WORKDIR /openedx/app/packages
 # Git clone all frontend apps that should be built
-RUN git clone --depth 1 --branch workspaces-dev https://github.com/arbrandes/frontend-base.git
 {% for app_name, app in iter_frontend_apps() %}
 {% if app.get("repository") %}
 RUN git clone --depth 1 --branch {{ app.get("version", MFE_COMMON_VERSION) }} {{ app["repository"] }} frontend-app-{{ app_name }}
@@ -104,7 +103,8 @@ RUN git clone --depth 1 --branch {{ app.get("version", MFE_COMMON_VERSION) }} {{
 {% endfor %}
 
 WORKDIR /openedx/app
-RUN npm install --no-audit --no-fund
+ARG NPM_REGISTRY={{ NPM_REGISTRY }}
+RUN --mount=type=cache,target=/root/.npm-sites,sharing=shared npm install --no-audit --no-fund --registry=$NPM_REGISTRY
 RUN npm run build:packages
 RUN PUBLIC_PATH="/site-{{ app.get("site", "default") }}/" npm run build
 {% endfor %}

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -22,7 +22,7 @@ ENV PATH=/openedx/app/node_modules/.bin:${PATH}
 
 {{ patch("mfe-dockerfile-base") }}
 
-{% for app_name, app in iter_mfes() %}
+{% for app_name, app in iter_all_apps() %}
 ####################### {{ app_name }} MFE
 ######## {{ app_name }} (git)
 FROM base AS {{ app_name }}-git
@@ -50,10 +50,10 @@ RUN --mount=type=cache,target=/root/.npm,sharing=shared npm clean-install --no-a
 {{ patch("mfe-dockerfile-post-npm-install-{}".format(app_name)) }}
 COPY --from={{ app_name }}-src / /openedx/app
 
+# While we figure out how translations will be managed  in template site
 {% if app_name != "template-site" %}
 RUN make OPENEDX_ATLAS_PULL=true ATLAS_OPTIONS="--repository={{ ATLAS_REPOSITORY }} --revision={{ ATLAS_REVISION }} {{ ATLAS_OPTIONS }}" pull_translations
 {% endif %}
-EXPOSE {{ app['port'] }}
 
 # Configuration needed at build time
 ENV APP_ID={{ app_name }}
@@ -67,6 +67,12 @@ COPY env.config.jsx /openedx/app
 {{ patch("mfe-dockerfile-pre-npm-build") }}
 {{ patch("mfe-dockerfile-pre-npm-build-{}".format(app_name)) }}
 
+{% if is_frontend_app_to_build(app_name) %}
+RUN TGZ_FILE=$(npm pack) && mv "$TGZ_FILE" {{app_name}}.tgz
+{% else %}
+EXPOSE {{ app['port'] }}
+{% endif %}
+
 ######## {{ app_name }} (dev)
 FROM {{ app_name }}-common AS {{ app_name }}-dev
 ENV NODE_ENV=development
@@ -77,6 +83,16 @@ CMD ["/bin/bash", "-c", "npm run start --- --config ./webpack.dev-tutor.config.j
 {%- for app_name, app in iter_mfes() %}
 ######## {{ app_name }} (production)
 FROM {{ app_name }}-common AS {{ app_name }}-prod
+
+{% if app_name == "template-site" %}
+    RUN mkdir -p /openedx/app/pack
+  {%- for app_name, app in iter_frontend_apps_to_build() %}
+    COPY --from={{ app_name }}-common /openedx/app/{{app_name}}.tgz /openedx/app/pack/
+    RUN npm install /openedx/app/pack/{{app_name}}.tgz --no-audit --no-fund
+  {% endfor %}
+  RUN npm ci
+{% endif %}
+
 ENV NODE_ENV=production
 RUN npm run build
 {{ patch("mfe-dockerfile-post-npm-build") }}

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -50,8 +50,9 @@ RUN --mount=type=cache,target=/root/.npm,sharing=shared npm clean-install --no-a
 {{ patch("mfe-dockerfile-post-npm-install-{}".format(app_name)) }}
 COPY --from={{ app_name }}-src / /openedx/app
 
+{% if app_name != "template-site" %}
 RUN make OPENEDX_ATLAS_PULL=true ATLAS_OPTIONS="--repository={{ ATLAS_REPOSITORY }} --revision={{ ATLAS_REVISION }} {{ ATLAS_OPTIONS }}" pull_translations
-
+{% endif %}
 EXPOSE {{ app['port'] }}
 
 # Configuration needed at build time

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -51,7 +51,8 @@ RUN --mount=type=cache,target=/root/.npm,sharing=shared npm clean-install --no-a
 COPY --from={{ app_name }}-src / /openedx/app
 
 # While we figure out how translations will be managed  in template site
-{% if app_name != "template-site" %}
+# if it's either template-site or starts with frontend-app, we skip pulling translations
+{% if app_name != "template-site" and not app_name.startswith("frontend-app") %}
 RUN make OPENEDX_ATLAS_PULL=true ATLAS_OPTIONS="--repository={{ ATLAS_REPOSITORY }} --revision={{ ATLAS_REVISION }} {{ ATLAS_OPTIONS }}" pull_translations
 {% endif %}
 
@@ -68,7 +69,7 @@ COPY env.config.jsx /openedx/app
 {{ patch("mfe-dockerfile-pre-npm-build-{}".format(app_name)) }}
 
 {% if is_frontend_app_to_build(app_name) %}
-RUN TGZ_FILE=$(npm pack) && mv "$TGZ_FILE" {{app_name}}.tgz
+RUN npm pack && mv *.tgz {{app_name}}.tgz
 {% else %}
 EXPOSE {{ app['port'] }}
 {% endif %}

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -117,9 +117,12 @@ WORKDIR /openedx/site
 COPY --from=site-{{ site_name }}-git /openedx/site/package.json /openedx/site
 
 ARG NPM_REGISTRY={{ NPM_REGISTRY }}
+{{ patch("frontend-site-dockerfile-pre-npm-install") }}
+
 {# This one we need to optimize, so the copy doesn't trigger a new npm install when it's not required #}
 RUN --mount=type=cache,target=/root/.npm-sites,sharing=shared npm install --no-audit --no-fund --registry=$NPM_REGISTRY
 
+{{ patch("frontend-site-dockerfile-post-npm-install") }}
 
 {%- endfor %}
 
@@ -135,7 +138,11 @@ COPY --from=site-{{ site_name }}-src /openedx/site /openedx/site
 {%- if ns.repos_exists %}
 RUN npm run build:packages
 {%- endif %}
+
+{{ patch("frontend-site-dockerfile-pre-npm-build") }}
 RUN PUBLIC_PATH="/site-{{ app.get("site", "default") }}/" npm run build
+{{ patch("frontend-site-dockerfile-post-npm-build") }}
+
 {%- endfor %}
 
 

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -22,7 +22,7 @@ ENV PATH=/openedx/app/node_modules/.bin:${PATH}
 
 {{ patch("mfe-dockerfile-base") }}
 
-{% for app_name, app in iter_all_apps() %}
+{% for app_name, app in iter_mfes() %}
 ####################### {{ app_name }} MFE
 ######## {{ app_name }} (git)
 FROM base AS {{ app_name }}-git
@@ -50,12 +50,6 @@ RUN --mount=type=cache,target=/root/.npm,sharing=shared npm clean-install --no-a
 {{ patch("mfe-dockerfile-post-npm-install-{}".format(app_name)) }}
 COPY --from={{ app_name }}-src / /openedx/app
 
-# While we figure out how translations will be managed  in template site
-# if it's either template-site or starts with frontend-app, we skip pulling translations
-{% if app_name != "template-site" and not app_name.startswith("frontend-app") %}
-RUN make OPENEDX_ATLAS_PULL=true ATLAS_OPTIONS="--repository={{ ATLAS_REPOSITORY }} --revision={{ ATLAS_REVISION }} {{ ATLAS_OPTIONS }}" pull_translations
-{% endif %}
-
 # Configuration needed at build time
 ENV APP_ID={{ app_name }}
 ENV PUBLIC_PATH='/{{ app_name }}/'
@@ -68,11 +62,7 @@ COPY env.config.jsx /openedx/app
 {{ patch("mfe-dockerfile-pre-npm-build") }}
 {{ patch("mfe-dockerfile-pre-npm-build-{}".format(app_name)) }}
 
-{% if is_frontend_app_to_build(app_name) %}
-RUN npm pack && mv *.tgz {{app_name}}.tgz
-{% else %}
 EXPOSE {{ app['port'] }}
-{% endif %}
 
 ######## {{ app_name }} (dev)
 FROM {{ app_name }}-common AS {{ app_name }}-dev
@@ -85,19 +75,37 @@ CMD ["/bin/bash", "-c", "npm run start --- --config ./webpack.dev-tutor.config.j
 ######## {{ app_name }} (production)
 FROM {{ app_name }}-common AS {{ app_name }}-prod
 
-{% if app_name == "template-site" %}
-    RUN mkdir -p /openedx/app/pack
-  {%- for app_name, app in iter_frontend_apps_to_build() %}
-    COPY --from={{ app_name }}-common /openedx/app/{{app_name}}.tgz /openedx/app/pack/
-    RUN npm install /openedx/app/pack/{{app_name}}.tgz --no-audit --no-fund
-  {% endfor %}
-  RUN npm ci
-{% endif %}
-
 ENV NODE_ENV=production
 RUN npm run build
 {{ patch("mfe-dockerfile-post-npm-build") }}
 {{ patch("mfe-dockerfile-post-npm-build-{}".format(app_name)) }}
+{% endfor %}
+
+
+{%- for app_name, app in iter_frontend_sites() %}
+######## build of site-{{ app_name }}
+FROM base AS site-{{ app_name }}-common
+WORKDIR /openedx/app
+
+{% if app.get("repository") and app["repository"] == "local" %}
+COPY frontend-site/ /openedx/app
+{% else %}
+RUN git clone --depth 1 --branch {{ app.get("version", MFE_COMMON_VERSION) }} {{ app["repository"] }} .
+{% endif %}
+
+WORKDIR /openedx/app/packages
+# Git clone all frontend apps that should be built
+RUN git clone --depth 1 --branch workspaces-dev https://github.com/arbrandes/frontend-base.git
+{% for app_name, app in iter_frontend_apps() %}
+{% if app.get("repository") %}
+RUN git clone --depth 1 --branch {{ app.get("version", MFE_COMMON_VERSION) }} {{ app["repository"] }} frontend-app-{{ app_name }}
+{% endif %}
+{% endfor %}
+
+WORKDIR /openedx/app
+RUN npm install --no-audit --no-fund
+RUN npm run build:packages
+RUN PUBLIC_PATH="/site-{{ app.get("site", "default") }}/" npm run build
 {% endfor %}
 
 ####### final production image with all static assets
@@ -108,6 +116,10 @@ RUN mkdir -p /openedx/dist
 # Copy static assets
 {% for app_name, app in iter_mfes() %}
 COPY --from={{ app_name }}-prod /openedx/app/dist /openedx/dist/{{ app_name }}
+{% endfor %}
+
+{% for app_name, app in iter_frontend_sites() %}
+COPY --from=site-{{ app_name }}-common /openedx/app/dist /openedx/dist/site-{{ app_name }}
 {% endfor %}
 
 {{ patch("mfe-dockerfile-production-final") }}

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -84,20 +84,27 @@ RUN npm run build
 
 
 {%- for site_name, app in iter_frontend_sites() %}
-######## build of site-{{ site_name }}
-FROM base AS site-{{ site_name }}-common
+######## build of site-{{ site_name }}-git
+FROM base AS site-{{ site_name }}-git
 WORKDIR /openedx/site
 
 # Either use site-local or the configured repository
 {%- if app.get("repository") and app["repository"] == "local" %}
 COPY frontend-site/ /openedx/site
 {%- else %}
-RUN git clone --depth 1 --branch {{ app.get("version", MFE_COMMON_VERSION) }} {{ app["repository"] }} .
+ADD --keep-git-dir=true {{ app["repository"] }}#{{ app.get("version", MFE_COMMON_VERSION) }} .
 {%- endif %}
+{%- endfor %}
 
-WORKDIR /openedx/site/packages
-# Git clone all frontend apps that should be built
+
 {%- set ns = namespace(repos_exists=0) %}
+{% for site_name, app in iter_frontend_sites() %}
+######## build of site-{{ site_name }}-src
+FROM base AS site-{{ site_name }}-src
+WORKDIR /openedx/site/packages
+
+# Git clone all frontend apps that should be built
+
 {%- for app_name, app in iter_frontend_apps() %}
 {%- if app.get("repository") %}
 RUN git clone --depth 1 --branch {{ app.get("version", MFE_COMMON_VERSION) }} {{ app["repository"] }} frontend-app-{{ app_name }}
@@ -106,13 +113,31 @@ RUN git clone --depth 1 --branch {{ app.get("version", MFE_COMMON_VERSION) }} {{
 {%- endfor %}
 
 WORKDIR /openedx/site
+
+COPY --from=site-{{ site_name }}-git /openedx/site/package.json /openedx/site
+
 ARG NPM_REGISTRY={{ NPM_REGISTRY }}
+{# This one we need to optimize, so the copy doesn't trigger a new npm install when it's not required #}
 RUN --mount=type=cache,target=/root/.npm-sites,sharing=shared npm install --no-audit --no-fund --registry=$NPM_REGISTRY
+
+
+{%- endfor %}
+
+
+{%- for site_name, app in iter_frontend_sites() %}
+######## build of site-{{ site_name }}-common
+FROM base AS site-{{ site_name }}-common
+WORKDIR /openedx/site
+
+COPY --from=site-{{ site_name }}-git /openedx/site/ /openedx/site
+COPY --from=site-{{ site_name }}-src /openedx/site /openedx/site
+
 {%- if ns.repos_exists %}
 RUN npm run build:packages
 {%- endif %}
 RUN PUBLIC_PATH="/site-{{ app.get("site", "default") }}/" npm run build
 {%- endfor %}
+
 
 ####### final production image with all static assets
 FROM {{ MFE_CADDY_DOCKER_IMAGE }} AS production

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -86,16 +86,16 @@ RUN npm run build
 {%- for site_name, app in iter_frontend_sites() %}
 ######## build of site-{{ site_name }}
 FROM base AS site-{{ site_name }}-common
-WORKDIR /openedx/app
+WORKDIR /openedx/site
 
 # Either use site-local or the configured repository
 {%- if app.get("repository") and app["repository"] == "local" %}
-COPY frontend-site/ /openedx/app
+COPY frontend-site/ /openedx/site
 {%- else %}
 RUN git clone --depth 1 --branch {{ app.get("version", MFE_COMMON_VERSION) }} {{ app["repository"] }} .
 {%- endif %}
 
-WORKDIR /openedx/app/packages
+WORKDIR /openedx/site/packages
 # Git clone all frontend apps that should be built
 {%- set ns = namespace(repos_exists=0) %}
 {%- for app_name, app in iter_frontend_apps() %}
@@ -105,7 +105,7 @@ RUN git clone --depth 1 --branch {{ app.get("version", MFE_COMMON_VERSION) }} {{
 {%- endif %}
 {%- endfor %}
 
-WORKDIR /openedx/app
+WORKDIR /openedx/site
 ARG NPM_REGISTRY={{ NPM_REGISTRY }}
 RUN --mount=type=cache,target=/root/.npm-sites,sharing=shared npm install --no-audit --no-fund --registry=$NPM_REGISTRY
 {%- if ns.repos_exists %}
@@ -125,7 +125,7 @@ COPY --from={{ app_name }}-prod /openedx/app/dist /openedx/dist/{{ app_name }}
 {% endfor %}
 
 {% for site_name, app in iter_frontend_sites() %}
-COPY --from=site-{{ site_name }}-common /openedx/app/dist /openedx/dist/site-{{ site_name }}
+COPY --from=site-{{ site_name }}-common /openedx/site/dist /openedx/dist/site-{{ site_name }}
 {% endfor %}
 
 {{ patch("mfe-dockerfile-production-final") }}

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -83,31 +83,36 @@ RUN npm run build
 {% endfor %}
 
 
-{%- for app_name, app in iter_frontend_sites() %}
-######## build of site-{{ app_name }}
-FROM base AS site-{{ app_name }}-common
+{%- for site_name, app in iter_frontend_sites() %}
+######## build of site-{{ site_name }}
+FROM base AS site-{{ site_name }}-common
 WORKDIR /openedx/app
 
-{% if app.get("repository") and app["repository"] == "local" %}
+# Either use site-local or the configured repository
+{%- if app.get("repository") and app["repository"] == "local" %}
 COPY frontend-site/ /openedx/app
-{% else %}
+{%- else %}
 RUN git clone --depth 1 --branch {{ app.get("version", MFE_COMMON_VERSION) }} {{ app["repository"] }} .
-{% endif %}
+{%- endif %}
 
 WORKDIR /openedx/app/packages
 # Git clone all frontend apps that should be built
-{% for app_name, app in iter_frontend_apps() %}
-{% if app.get("repository") %}
+{%- set ns = namespace(repos_exists=0) %}
+{%- for app_name, app in iter_frontend_apps() %}
+{%- if app.get("repository") %}
 RUN git clone --depth 1 --branch {{ app.get("version", MFE_COMMON_VERSION) }} {{ app["repository"] }} frontend-app-{{ app_name }}
-{% endif %}
-{% endfor %}
+{%- set ns.repos_exists = 1 %}
+{%- endif %}
+{%- endfor %}
 
 WORKDIR /openedx/app
 ARG NPM_REGISTRY={{ NPM_REGISTRY }}
 RUN --mount=type=cache,target=/root/.npm-sites,sharing=shared npm install --no-audit --no-fund --registry=$NPM_REGISTRY
+{%- if ns.repos_exists %}
 RUN npm run build:packages
+{%- endif %}
 RUN PUBLIC_PATH="/site-{{ app.get("site", "default") }}/" npm run build
-{% endfor %}
+{%- endfor %}
 
 ####### final production image with all static assets
 FROM {{ MFE_CADDY_DOCKER_IMAGE }} AS production
@@ -119,8 +124,8 @@ RUN mkdir -p /openedx/dist
 COPY --from={{ app_name }}-prod /openedx/app/dist /openedx/dist/{{ app_name }}
 {% endfor %}
 
-{% for app_name, app in iter_frontend_sites() %}
-COPY --from=site-{{ app_name }}-common /openedx/app/dist /openedx/dist/site-{{ app_name }}
+{% for site_name, app in iter_frontend_sites() %}
+COPY --from=site-{{ site_name }}-common /openedx/app/dist /openedx/dist/site-{{ site_name }}
 {% endfor %}
 
 {{ patch("mfe-dockerfile-production-final") }}

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/Makefile
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/Makefile
@@ -1,0 +1,23 @@
+TURBO = TURBO_TELEMETRY_DISABLED=1 turbo --dangerously-disable-package-manager-check
+
+.PHONY: bin-link build-packages clean-packages clean dev-packages
+
+# NPM doesn't bin-link workspace packages during install, so it must be done manually.
+bin-link:
+	[ -f packages/frontend-base/package.json ] && npm rebuild --ignore-scripts @openedx/frontend-base || true
+
+build-packages:
+	$(TURBO) run build
+	$(MAKE) bin-link
+
+clean-packages:
+	$(TURBO) run clean
+
+dev-packages:
+	$(TURBO) run watch:build dev:site
+
+dev-site: bin-link
+	npm run dev
+
+clean:
+	rm -rf dist

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/package.json
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/package.json
@@ -35,9 +35,9 @@
   "dependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
 {%- for app_name, app_attrs in iter_frontend_apps() %}
-    "@openedx/frontend-app-{{ app_name }}": "^1.0.0",
+    "@openedx/frontend-app-{{ app_name }}": "^1.0.0-alpha || 0.0.0-dev",
 {%- endfor %}
-    "@openedx/frontend-base": "^1.0.0-alpha.14"
+    "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev"
   },
   "devDependencies": {
     "@edx/browserslist-config": "^1.5.0",

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/package.json
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/package.json
@@ -1,11 +1,5 @@
 {
-  "name": "@openedx/frontend-template-site",
   "version": "1.0.0",
-  "description": "Tutor rontend site",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/openedx/frontend-template-site.git"
-  },
   "workspaces": [
     "packages/*"
   ],
@@ -26,16 +20,13 @@
     "clean": "make clean",
     "serve": "openedx serve"
   },
-  "author": "Open edX",
-  "license": "AGPL-3.0",
-  "homepage": "https://github.com/openedx/frontend-template-site#readme",
-  "bugs": {
-    "url": "https://github.com/openedx/frontend-template-site/issues"
-  },
   "dependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
 {%- for app_name, app_attrs in iter_frontend_apps() %}
-    "{{ app_attrs.get('entryPoints', {}).get('packageName', app_name) }}": "{{ app_attrs.get('entryPoints', {}).get('packageVersion', '^1.0.0-alpha || 0.0.0-dev') }}",
+{%- set entry_points = app_attrs.get('appEntryPoints', {}).get('packageName', False) %}
+{%- if entry_points %}
+    "{{ app_attrs.get('appEntryPoints', {}).get('packageName', app_name) }}": "{{ app_attrs.get('appEntryPoints', {}).get('packageVersion', '^1.0.0-alpha || 0.0.0-dev') }}",
+{%- endif %}
 {%- endfor %}
     "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev"
   },

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/package.json
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/package.json
@@ -1,3 +1,4 @@
+{%- set defaultSite = get_frontend_sites().get('default', {}) %}
 {
   "version": "1.0.0",
   "workspaces": [
@@ -21,14 +22,15 @@
     "serve": "openedx serve"
   },
   "dependencies": {
-    "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
+    "@edx/brand": "npm:@openedx/brand-openedx@latest",
 {%- for app_name, app_attrs in iter_frontend_apps() %}
 {%- set entry_points = app_attrs.get('appEntryPoints', {}).get('packageName', False) %}
 {%- if entry_points %}
     "{{ app_attrs.get('appEntryPoints', {}).get('packageName', app_name) }}": "{{ app_attrs.get('appEntryPoints', {}).get('packageVersion', '^1.0.0-alpha || 0.0.0-dev') }}",
 {%- endif %}
 {%- endfor %}
-    "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev"
+{#- This allows version config and alias config  #}
+    "@openedx/frontend-base": "{{ defaultSite.get('siteConfig', {}).get('frontendBaseVersion', '^1.0.0-alpha || 0.0.0-dev') }}"
   },
   "devDependencies": {
     "@edx/browserslist-config": "^1.5.0",

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/package.json
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/package.json
@@ -1,4 +1,4 @@
-{%- set defaultSite = get_frontend_sites().get('default', {}) %}
+{%- set defaultSite = get_frontend_site('default') %}
 {
   "version": "1.0.0",
   "workspaces": [

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/package.json
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openedx/frontend-template-site",
   "version": "1.0.0",
-  "description": "Frontend site template",
+  "description": "Tutor rontend site",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openedx/frontend-template-site.git"
@@ -35,7 +35,7 @@
   "dependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
 {%- for app_name, app_attrs in iter_frontend_apps() %}
-    "@openedx/frontend-app-{{ app_name }}": "^1.0.0-alpha || 0.0.0-dev",
+    "{{ app_attrs.get('entryPoints', {}).get('packageName', app_name) }}": "{{ app_attrs.get('entryPoints', {}).get('packageVersion', '^1.0.0-alpha || 0.0.0-dev') }}",
 {%- endfor %}
     "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev"
   },

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/package.json
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/package.json
@@ -33,11 +33,11 @@
     "@openedx/frontend-base": "{{ defaultSite.get('siteConfig', {}).get('frontendBaseVersion', '^1.0.0-alpha || 0.0.0-dev') }}"
   },
   "devDependencies": {
-    "@edx/browserslist-config": "^1.5.0",
+    "@edx/browserslist-config": "latest",
     "turbo": "^2.8.16"
   },
   "peerDependencies": {
-    "@openedx/paragon": "^23",
+    "@openedx/paragon": "{{ defaultSite.get('siteConfig', {}).get('paragonVersion', '^23') }}",
     "@tanstack/react-query": "^5",
     "react": "^18",
     "react-dom": "^18",

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/package.json
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/package.json
@@ -1,0 +1,47 @@
+{%- set defaultSite = get_frontend_site('default') %}
+{
+  "version": "1.0.0",
+  "workspaces": [
+    "packages/*"
+  ],
+  "browserslist": [
+    "extends @edx/browserslist-config"
+  ],
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
+  "scripts": {
+    "build": "openedx build",
+    "build:packages": "make build-packages",
+    "clean:packages": "make clean-packages",
+    "dev": "PORT=8080 openedx dev",
+    "dev:site": "make dev-site",
+    "dev:packages": "make dev-packages",
+    "clean": "make clean",
+    "serve": "openedx serve"
+  },
+  "dependencies": {
+    "@edx/brand": "npm:@openedx/brand-openedx@latest",
+{%- for app_name, app_attrs in iter_frontend_apps() %}
+{%- set entry_points = app_attrs.get('appEntryPoints', {}).get('packageName', False) %}
+{%- if entry_points %}
+    "{{ app_attrs.get('appEntryPoints', {}).get('packageName', app_name) }}": "{{ app_attrs.get('appEntryPoints', {}).get('packageVersion', '^1.0.0-alpha || 0.0.0-dev') }}",
+{%- endif %}
+{%- endfor %}
+{#- This allows version config and alias config  #}
+    "@openedx/frontend-base": "{{ defaultSite.get('siteConfig', {}).get('frontendBaseVersion', '^1.0.0-alpha || 0.0.0-dev') }}"
+  },
+  "devDependencies": {
+    "@edx/browserslist-config": "latest",
+    "turbo": "^2.8.16"
+  },
+  "peerDependencies": {
+    "@openedx/paragon": "{{ defaultSite.get('siteConfig', {}).get('paragonVersion', '^23') }}",
+    "@tanstack/react-query": "^5",
+    "react": "^18",
+    "react-dom": "^18",
+    "react-router": "^6",
+    "react-router-dom": "^6"
+  }
+}

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/package.json
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@openedx/frontend-template-site",
+  "version": "1.0.0",
+  "description": "Frontend site template",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openedx/frontend-template-site.git"
+  },
+  "workspaces": [
+    "packages/*"
+  ],
+  "browserslist": [
+    "extends @edx/browserslist-config"
+  ],
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
+  "scripts": {
+    "build": "openedx build",
+    "build:packages": "make build-packages",
+    "clean:packages": "make clean-packages",
+    "dev": "PORT=8080 openedx dev",
+    "dev:site": "make dev-site",
+    "dev:packages": "make dev-packages",
+    "clean": "make clean",
+    "serve": "openedx serve"
+  },
+  "author": "Open edX",
+  "license": "AGPL-3.0",
+  "homepage": "https://github.com/openedx/frontend-template-site#readme",
+  "bugs": {
+    "url": "https://github.com/openedx/frontend-template-site/issues"
+  },
+  "dependencies": {
+    "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
+{%- for app_name, app_attrs in iter_frontend_apps() %}
+    "@openedx/frontend-app-{{ app_name }}": "^1.0.0",
+{%- endfor %}
+    "@openedx/frontend-base": "^1.0.0-alpha.14"
+  },
+  "devDependencies": {
+    "@edx/browserslist-config": "^1.5.0",
+    "turbo": "^2.8.16"
+  },
+  "peerDependencies": {
+    "@openedx/paragon": "^23",
+    "@tanstack/react-query": "^5",
+    "react": "^18",
+    "react-dom": "^18",
+    "react-router": "^6",
+    "react-router-dom": "^6"
+  }
+}

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/public/index.html
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/public/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+      <title>Frontend Template Site</title>
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/public/index.html
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/public/index.html
@@ -1,11 +1,14 @@
 <!doctype html>
 <html lang="en-us">
-  <head>
-      <title>Frontend Template Site</title>
-      <meta charset="utf-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  </head>
-  <body>
-    <div id="root"></div>
-  </body>
+
+<head>
+  <title>{{ PLATFORM_NAME }}</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+
+<body>
+  <div id="root"></div>
+</body>
+
 </html>

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.build.tsx
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.build.tsx
@@ -11,7 +11,7 @@ import slotsApp from './src/slotsApp';
 
 import './src/site.scss';
 
-{%- set defaultSite = get_frontend_sites().get('default', {}) %}
+{%- set defaultSite = get_frontend_site('default') %}
 const siteConfig: SiteConfig = {
   siteId: {{defaultSite.get('siteConfig', {}).get('siteId', '"tutor-frontend-site"') | tojson }},
   siteName: {{defaultSite.get('siteConfig', {}).get('siteName', '"Frontend site"') | tojson }},

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.build.tsx
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.build.tsx
@@ -1,0 +1,49 @@
+import { EnvironmentTypes, SiteConfig, footerApp, headerApp, shellApp } from '@openedx/frontend-base';
+{%- for app_name, app_attrs in iter_frontend_apps() %}
+{%- set components = app_attrs.get('appEntryPoints', {}).get('components', []) %}
+{%- if components %}
+import { {{ components | join(', ') }} } from '{{ app_attrs.get('appEntryPoints', {}).get('packageName', app_name) }}';
+{%- endif %}
+{%- endfor %}
+import homeApp from './src/homeApp';
+import slotsApp from './src/slotsApp';
+
+
+import './src/site.scss';
+
+{%- set defaultSite = get_frontend_site('default') %}
+const siteConfig: SiteConfig = {
+  siteId: {{defaultSite.get('siteConfig', {}).get('siteId', '"tutor-frontend-site"') | tojson }},
+  siteName: {{defaultSite.get('siteConfig', {}).get('siteName', '"Frontend site"') | tojson }},
+  baseUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ MFE_HOST }}:8080',
+  lmsBaseUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000',
+  loginUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000/login',
+  logoutUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000/logout',
+
+  environment: EnvironmentTypes.PRODUCTION,
+  apps: [
+    shellApp,
+    headerApp,
+    footerApp,
+{%- for app_name, app_attrs in iter_frontend_apps() %}
+{%- set components = app_attrs.get('appEntryPoints', {}).get('components', []) %}
+{%- if components %}
+    {{ components | join(',') }},
+{%- endif %}
+{%- endfor %}
+    homeApp,
+    slotsApp,
+  ],
+  externalRoutes: [
+    {%- for route in defaultSite.get('siteConfig', {}).get('externalRoutes', []) %}
+    {
+      role: '{{ route.role }}',
+      url: '{{ 'https' if ENABLE_HTTPS else 'http' }}://{{ MFE_HOST }}{{ route.url }}',
+    },
+    {%- endfor %}
+  ],
+
+  accessTokenCookieName: {{ defaultSite.get('siteConfig', {}).get('accessTokenCookieName', '"edx-jwt-cookie-header-payload"') | tojson }},
+};
+
+export default siteConfig;

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.build.tsx
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.build.tsx
@@ -6,6 +6,7 @@ import { {{ components | join(', ') }} } from '{{ app_attrs.get('appEntryPoints'
 {%- endif %}
 {%- endfor %}
 import homeApp from './src/homeApp';
+import slotsApp from './src/slotsApp';
 
 
 import './src/site.scss';
@@ -13,7 +14,7 @@ import './src/site.scss';
 {%- set defaultSite = get_frontend_sites().get('default', {}) %}
 const siteConfig: SiteConfig = {
   siteId: {{defaultSite.get('siteConfig', {}).get('siteId', '"tutor-frontend-site"') | tojson }},
-  siteName: {{defaultSite.get('siteConfig', {}).get('siteName', '"Frontend Template Site"') | tojson }},
+  siteName: {{defaultSite.get('siteConfig', {}).get('siteName', '"Frontend site"') | tojson }},
   baseUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ MFE_HOST }}:8080',
   lmsBaseUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000',
   loginUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000/login',
@@ -31,6 +32,7 @@ const siteConfig: SiteConfig = {
 {%- endif %}
 {%- endfor %}
     homeApp,
+    slotsApp,
   ],
   externalRoutes: [
     {%- for route in defaultSite.get('siteConfig', {}).get('externalRoutes', []) %}

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.build.tsx
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.build.tsx
@@ -1,8 +1,9 @@
 import { EnvironmentTypes, SiteConfig, footerApp, headerApp, shellApp } from '@openedx/frontend-base';
 {%- for app_name, app_attrs in iter_frontend_apps() %}
-{%- set camel_case_name = app_name.split('-') | map('title') | list %}
-{%- set camel_case_name = camel_case_name[0].lower() + (camel_case_name[1:] | join('')) %}
-import { {{ camel_case_name }}App } from '@openedx/frontend-app-{{ app_name }}';
+{%- set components = app_attrs.get('appEntryPoints', {}).get('components', []) %}
+{% if components %}
+import { {{ components | join(', ') }} } from '{{ app_attrs.get('appEntryPoints', {}).get('packageName', app_name) }}';
+{% endif %}
 {%- endfor %}
 import homeApp from './src/homeApp';
 
@@ -23,9 +24,10 @@ const siteConfig: SiteConfig = {
     headerApp,
     footerApp,
 {%- for app_name, app_attrs in iter_frontend_apps() %}
-{%- set camel_case_name = app_name.split('-') | map('title') | list %}
-{%- set camel_case_name = camel_case_name[0].lower() + (camel_case_name[1:] | join('')) %}
-    {{ camel_case_name }}App,
+{%- set components = app_attrs.get('appEntryPoints', {}).get('components', []) %}
+{%- if components %}
+    {{ components | join(',') }},
+{%- endif %}
 {%- endfor %}
     homeApp,
   ],

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.build.tsx
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.build.tsx
@@ -1,9 +1,9 @@
 import { EnvironmentTypes, SiteConfig, footerApp, headerApp, shellApp } from '@openedx/frontend-base';
 {%- for app_name, app_attrs in iter_frontend_apps() %}
 {%- set components = app_attrs.get('appEntryPoints', {}).get('components', []) %}
-{% if components %}
+{%- if components %}
 import { {{ components | join(', ') }} } from '{{ app_attrs.get('appEntryPoints', {}).get('packageName', app_name) }}';
-{% endif %}
+{%- endif %}
 {%- endfor %}
 import homeApp from './src/homeApp';
 

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.build.tsx
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.build.tsx
@@ -10,9 +10,10 @@ import homeApp from './src/homeApp';
 
 import './src/site.scss';
 
+{%- set defaultSite = get_frontend_sites().get('default', {}) %}
 const siteConfig: SiteConfig = {
-  siteId: 'frontend-template-site',
-  siteName: 'Frontend Template Site',
+  siteId: {{defaultSite.get('siteConfig', {}).get('siteId', '"tutor-frontend-site"') | tojson }},
+  siteName: {{defaultSite.get('siteConfig', {}).get('siteName', '"Frontend Template Site"') | tojson }},
   baseUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ MFE_HOST }}:8080',
   lmsBaseUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000',
   loginUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000/login',
@@ -32,21 +33,15 @@ const siteConfig: SiteConfig = {
     homeApp,
   ],
   externalRoutes: [
+    {%- for route in defaultSite.get('siteConfig', {}).get('externalRoutes', []) %}
     {
-      role: 'org.openedx.frontend.role.profile',
-      url: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ MFE_HOST }}/profile/'
+      role: '{{ route.role }}',
+      url: '{{ 'https' if ENABLE_HTTPS else 'http' }}://{{ MFE_HOST }}{{ route.url }}',
     },
-    {
-      role: 'org.openedx.frontend.role.account',
-      url: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ MFE_HOST }}/account/'
-    },
-    {
-      role: 'org.openedx.frontend.role.logout',
-      url: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}/logout'
-    },
+    {%- endfor %}
   ],
 
-  accessTokenCookieName: 'edx-jwt-cookie-header-payload',
+  accessTokenCookieName: {{ defaultSite.get('siteConfig', {}).get('accessTokenCookieName', '"edx-jwt-cookie-header-payload"') | tojson }},
 };
 
 export default siteConfig;

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.build.tsx
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.build.tsx
@@ -1,0 +1,50 @@
+import { EnvironmentTypes, SiteConfig, footerApp, headerApp, shellApp } from '@openedx/frontend-base';
+{%- for app_name, app_attrs in iter_frontend_apps() %}
+{%- set camel_case_name = app_name.split('-') | map('title') | list %}
+{%- set camel_case_name = camel_case_name[0].lower() + (camel_case_name[1:] | join('')) %}
+import { {{ camel_case_name }}App } from '@openedx/frontend-app-{{ app_name }}';
+{%- endfor %}
+import homeApp from './src/homeApp';
+
+
+import './src/site.scss';
+
+const siteConfig: SiteConfig = {
+  siteId: 'frontend-template-site',
+  siteName: 'Frontend Template Site',
+  baseUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ MFE_HOST }}:8080',
+  lmsBaseUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000',
+  loginUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000/login',
+  logoutUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000/logout',
+
+  environment: EnvironmentTypes.PRODUCTION,
+  apps: [
+    shellApp,
+    headerApp,
+    footerApp,
+{%- for app_name, app_attrs in iter_frontend_apps() %}
+{%- set camel_case_name = app_name.split('-') | map('title') | list %}
+{%- set camel_case_name = camel_case_name[0].lower() + (camel_case_name[1:] | join('')) %}
+    {{ camel_case_name }}App,
+{%- endfor %}
+    homeApp,
+  ],
+  externalRoutes: [
+    {
+      role: 'org.openedx.frontend.role.profile',
+      url: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ MFE_HOST }}/profile/'
+    },
+    {
+      role: 'org.openedx.frontend.role.account',
+      url: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ MFE_HOST }}/account/'
+    },
+    {
+      role: 'org.openedx.frontend.role.logout',
+      url: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}/logout'
+    },
+  ],
+
+  accessTokenCookieName: 'edx-jwt-cookie-header-payload',
+};
+
+export default siteConfig;

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.dev.tsx
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.dev.tsx
@@ -1,15 +1,19 @@
 import { EnvironmentTypes, SiteConfig, footerApp, headerApp, shellApp } from '@openedx/frontend-base';
 {%- for app_name, app_attrs in iter_frontend_apps() %}
-{%- set camel_case_name = app_name.split('-') | map('title') | list %}
-{%- set camel_case_name = camel_case_name[0].lower() + (camel_case_name[1:] | join('')) %}
-import { {{ camel_case_name }}App } from '@openedx/frontend-app-{{ app_name }}';
+{%- set components = app_attrs.get('appEntryPoints', {}).get('components', []) %}
+{%- if components %}
+import { {{ components | join(', ') }} } from '{{ app_attrs.get('appEntryPoints', {}).get('packageName', app_name) }}';
+{%- endif %}
 {%- endfor %}
+import homeApp from './src/homeApp';
+
 
 import './src/site.scss';
 
+{%- set defaultSite = get_frontend_sites().get('default', {}) %}
 const siteConfig: SiteConfig = {
-  siteId: 'frontend-template-site',
-  siteName: 'Frontend Template Site',
+  siteId: {{defaultSite.get('siteConfig', {}).get('siteId', '"tutor-frontend-site"') | tojson }},
+  siteName: {{defaultSite.get('siteConfig', {}).get('siteName', '"Frontend Template Site"') | tojson }},
   baseUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ MFE_HOST }}:8080',
   lmsBaseUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000',
   loginUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000/login',
@@ -21,27 +25,23 @@ const siteConfig: SiteConfig = {
     headerApp,
     footerApp,
 {%- for app_name, app_attrs in iter_frontend_apps() %}
-{%- set camel_case_name = app_name.split('-') | map('title') | list %}
-{%- set camel_case_name = camel_case_name[0].lower() + (camel_case_name[1:] | join('')) %}
-    {{ camel_case_name }}App,
+{%- set components = app_attrs.get('appEntryPoints', {}).get('components', []) %}
+{%- if components %}
+    {{ components | join(',') }},
+{%- endif %}
 {%- endfor %}
+    homeApp,
   ],
   externalRoutes: [
+    {%- for route in defaultSite.get('siteConfig', {}).get('externalRoutes', []) %}
     {
-      role: 'org.openedx.frontend.role.profile',
-      url: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ MFE_HOST }}:1995/profile/'
+      role: '{{ route.role }}',
+      url: '{{ 'https' if ENABLE_HTTPS else 'http' }}://{{ MFE_HOST }}{{ route.url }}',
     },
-    {
-      role: 'org.openedx.frontend.role.account',
-      url: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ MFE_HOST }}:1997/account/'
-    },
-    {
-      role: 'org.openedx.frontend.role.logout',
-      url: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000/logout'
-    },
+    {%- endfor %}
   ],
 
-  accessTokenCookieName: 'edx-jwt-cookie-header-payload',
+  accessTokenCookieName: {{ defaultSite.get('siteConfig', {}).get('accessTokenCookieName', '"edx-jwt-cookie-header-payload"') | tojson }},
 };
 
 export default siteConfig;

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.dev.tsx
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.dev.tsx
@@ -1,0 +1,47 @@
+import { EnvironmentTypes, SiteConfig, footerApp, headerApp, shellApp } from '@openedx/frontend-base';
+{%- for app_name, app_attrs in iter_frontend_apps() %}
+{%- set camel_case_name = app_name.split('-') | map('title') | list %}
+{%- set camel_case_name = camel_case_name[0].lower() + (camel_case_name[1:] | join('')) %}
+import { {{ camel_case_name }}App } from '@openedx/frontend-app-{{ app_name }}';
+{%- endfor %}
+
+import './src/site.scss';
+
+const siteConfig: SiteConfig = {
+  siteId: 'frontend-template-site',
+  siteName: 'Frontend Template Site',
+  baseUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ MFE_HOST }}:8080',
+  lmsBaseUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000',
+  loginUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000/login',
+  logoutUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000/logout',
+
+  environment: EnvironmentTypes.DEVELOPMENT,
+  apps: [
+    shellApp,
+    headerApp,
+    footerApp,
+{%- for app_name, app_attrs in iter_frontend_apps() %}
+{%- set camel_case_name = app_name.split('-') | map('title') | list %}
+{%- set camel_case_name = camel_case_name[0].lower() + (camel_case_name[1:] | join('')) %}
+    {{ camel_case_name }}App,
+{%- endfor %}
+  ],
+  externalRoutes: [
+    {
+      role: 'org.openedx.frontend.role.profile',
+      url: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ MFE_HOST }}:1995/profile/'
+    },
+    {
+      role: 'org.openedx.frontend.role.account',
+      url: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ MFE_HOST }}:1997/account/'
+    },
+    {
+      role: 'org.openedx.frontend.role.logout',
+      url: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000/logout'
+    },
+  ],
+
+  accessTokenCookieName: 'edx-jwt-cookie-header-payload',
+};
+
+export default siteConfig;

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.dev.tsx
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.dev.tsx
@@ -10,7 +10,7 @@ import homeApp from './src/homeApp';
 
 import './src/site.scss';
 
-{%- set defaultSite = get_frontend_sites().get('default', {}) %}
+{%- set defaultSite = get_frontend_site('default') %}
 const siteConfig: SiteConfig = {
   siteId: {{defaultSite.get('siteConfig', {}).get('siteId', '"tutor-frontend-site"') | tojson }},
   siteName: {{defaultSite.get('siteConfig', {}).get('siteName', '"Frontend Template Site"') | tojson }},

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.dev.tsx
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/site.config.dev.tsx
@@ -1,0 +1,47 @@
+import { EnvironmentTypes, SiteConfig, footerApp, headerApp, shellApp } from '@openedx/frontend-base';
+{%- for app_name, app_attrs in iter_frontend_apps() %}
+{%- set components = app_attrs.get('appEntryPoints', {}).get('components', []) %}
+{%- if components %}
+import { {{ components | join(', ') }} } from '{{ app_attrs.get('appEntryPoints', {}).get('packageName', app_name) }}';
+{%- endif %}
+{%- endfor %}
+import homeApp from './src/homeApp';
+
+
+import './src/site.scss';
+
+{%- set defaultSite = get_frontend_site('default') %}
+const siteConfig: SiteConfig = {
+  siteId: {{defaultSite.get('siteConfig', {}).get('siteId', '"tutor-frontend-site"') | tojson }},
+  siteName: {{defaultSite.get('siteConfig', {}).get('siteName', '"Frontend Template Site"') | tojson }},
+  baseUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ MFE_HOST }}:8080',
+  lmsBaseUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000',
+  loginUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000/login',
+  logoutUrl: '{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}:8000/logout',
+
+  environment: EnvironmentTypes.DEVELOPMENT,
+  apps: [
+    shellApp,
+    headerApp,
+    footerApp,
+{%- for app_name, app_attrs in iter_frontend_apps() %}
+{%- set components = app_attrs.get('appEntryPoints', {}).get('components', []) %}
+{%- if components %}
+    {{ components | join(',') }},
+{%- endif %}
+{%- endfor %}
+    homeApp,
+  ],
+  externalRoutes: [
+    {%- for route in defaultSite.get('siteConfig', {}).get('externalRoutes', []) %}
+    {
+      role: '{{ route.role }}',
+      url: '{{ 'https' if ENABLE_HTTPS else 'http' }}://{{ MFE_HOST }}{{ route.url }}',
+    },
+    {%- endfor %}
+  ],
+
+  accessTokenCookieName: {{ defaultSite.get('siteConfig', {}).get('accessTokenCookieName', '"edx-jwt-cookie-header-payload"') | tojson }},
+};
+
+export default siteConfig;

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/src/homeApp.ts
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/src/homeApp.ts
@@ -1,0 +1,18 @@
+import { App, getUrlByRouteRole } from '@openedx/frontend-base';
+import { redirect } from 'react-router';
+
+const homeApp: App = {
+  appId: 'home',
+  routes: [{
+    path: '/',
+    loader: () => {
+      const dashboardUrl = getUrlByRouteRole('org.openedx.frontend.role.dashboard');
+      if (dashboardUrl) {
+        return redirect(dashboardUrl);
+      }
+      throw new Response('Not Found', { status: 404 });
+    },
+  }],
+};
+
+export default homeApp;

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/src/homeApp.ts
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/src/homeApp.ts
@@ -1,12 +1,13 @@
 import { App, getUrlByRouteRole } from '@openedx/frontend-base';
 import { redirect } from 'react-router';
 
+{%- set defaultSite = get_frontend_sites().get('default', {}) %}
 const homeApp: App = {
   appId: 'home',
   routes: [{
     path: '/',
     loader: () => {
-      const dashboardUrl = getUrlByRouteRole('org.openedx.frontend.role.dashboard');
+      const dashboardUrl = getUrlByRouteRole('{{ defaultSite.get('siteConfig', {}).get('redirectRoleId', '') }}');
       if (dashboardUrl) {
         return redirect(dashboardUrl);
       }

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/src/homeApp.ts
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/src/homeApp.ts
@@ -1,7 +1,7 @@
 import { App, getUrlByRouteRole } from '@openedx/frontend-base';
 import { redirect } from 'react-router';
 
-{%- set defaultSite = get_frontend_sites().get('default', {}) %}
+{%- set defaultSite = get_frontend_site('default') %}
 const homeApp: App = {
   appId: 'home',
   routes: [{

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/src/homeApp.ts
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/src/homeApp.ts
@@ -1,0 +1,19 @@
+import { App, getUrlByRouteRole } from '@openedx/frontend-base';
+import { redirect } from 'react-router';
+
+{%- set defaultSite = get_frontend_site('default') %}
+const homeApp: App = {
+  appId: 'home',
+  routes: [{
+    path: '/',
+    loader: () => {
+      const dashboardUrl = getUrlByRouteRole('{{ defaultSite.get('siteConfig', {}).get('redirectRoleId', '') }}');
+      if (dashboardUrl) {
+        return redirect(dashboardUrl);
+      }
+      throw new Response('Not Found', { status: 404 });
+    },
+  }],
+};
+
+export default homeApp;

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/src/site.scss
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/src/site.scss
@@ -1,6 +1,6 @@
 @use '@openedx/frontend-base/shell/app.scss' as shell;
 {%- for app_name, app_attrs in iter_frontend_apps() %}
 {%- for styleName in app_attrs.get('appEntryPoints', {}).get('styles', []) %}
-@use '{{ app_attrs.get('appEntryPoints', {}).get('packageName', 'style.scss') }}/{{ styleName }}';
+@use '{{ app_attrs.get('appEntryPoints', {}).get('packageName', 'style.scss') }}/{{ styleName }}' as {{ app_name }};
 {%- endfor %}
 {%- endfor %}

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/src/site.scss
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/src/site.scss
@@ -1,0 +1,6 @@
+@use '@openedx/frontend-base/shell/app.scss' as shell;
+{%- for app_name, app_attrs in iter_frontend_apps() %}
+{%- set camel_case_name = app_name.split('-') | map('title') | list %}
+{%- set camel_case_name = camel_case_name[0].lower() + (camel_case_name[1:] | join('')) %}
+@use '@openedx/frontend-app-{{ app_name }}/app.scss' as {{ camel_case_name }};
+{%- endfor %}

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/src/site.scss
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/src/site.scss
@@ -1,6 +1,6 @@
 @use '@openedx/frontend-base/shell/app.scss' as shell;
 {%- for app_name, app_attrs in iter_frontend_apps() %}
-{%- set camel_case_name = app_name.split('-') | map('title') | list %}
-{%- set camel_case_name = camel_case_name[0].lower() + (camel_case_name[1:] | join('')) %}
-@use '@openedx/frontend-app-{{ app_name }}/app.scss' as {{ camel_case_name }};
+{%- for styleName in app_attrs.get('appEntryPoints', {}).get('styles', []) %}
+@use '{{ app_attrs.get('appEntryPoints', {}).get('packageName', 'style.scss') }}/{{ styleName }}';
+{%- endfor %}
 {%- endfor %}

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/src/slotsApp.tsx
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/src/slotsApp.tsx
@@ -2,8 +2,6 @@ import { App, WidgetOperationTypes } from '@openedx/frontend-base';
 
 {{- patch("frontend-slots-env-config-buildtime-imports") }}
 
-{{- patch("frontend-slots-env-config-buildtime-definitions") }}
-
 const slotsApp: App = {
   appId: 'slots',
   slots: [

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/src/slotsApp.tsx
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/src/slotsApp.tsx
@@ -1,0 +1,16 @@
+import { App, WidgetOperationTypes } from '@openedx/frontend-base';
+
+{{- patch("frontend-slots-env-config-buildtime-imports") }}
+
+{{- patch("frontend-slots-env-config-buildtime-definitions") }}
+
+const slotsApp: App = {
+  appId: 'slots',
+  slots: [
+    {%- for slot_name, slot_config in iter_frontend_slots() %}
+    {{ slot_config }},
+    {%- endfor %}
+  ]
+};
+
+export default slotsApp;

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/tsconfig.json
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@openedx/frontend-base/tools/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+  },
+  "include": [
+    "src/**/*",
+    "app.d.ts",
+    "eslint.config.js",
+    "site.config.*.tsx",
+  ],
+}

--- a/tutormfe/templates/mfe/build/mfe/frontend-site/turbo.json
+++ b/tutormfe/templates/mfe/build/mfe/frontend-site/turbo.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
+      "cache": false
+    },
+    "clean": {
+      "cache": false
+    },
+    "watch:build": {
+      "dependsOn": ["^build"],
+      "persistent": true,
+      "cache": false
+    },
+    "//#dev:site": {
+      "dependsOn": ["^build"],
+      "persistent": true,
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
## Basic details
This is the first step for the build process of the frontend apps, what it does:

- Adds a new filter (`FRONTEND_APPS`) that will be used to know which apps should be frontendbase
- Adds a new filter (`FRONTEND_SITES`) to know which "sites" are going to be build, by default we have a local one but operators are going to be able to override the default one or add extra ones
- Adds CORS patches for the configured sites
- Adds general functions to iterate and get the right information for the new filters
- Adds a utility `iter_paths` which returns the paths that should be used in the Caddyfile, taking in account that they could be either from the old MFEs or from a new frontendapp that didn't have MFE before
- Adds utility `is_frontend_app` which checks if the app is "enabled" as a frontend app so Caddy does some path magic
- Caddyfile know checks if the path is for a frontend enabled app so it returns the right folder for it based on config and serves all possible frontend-sites
- Adds all the basic files for a frontend-site to be build
  - The files have templating so any configured frontendapp is added dynamically to `package.json` and `site.scss`
  - templating for right domains in `site.config.x.tsx`


## Pending things
- Figure the mounting things for sites and frontend apps
- use right site.config based on being dev or prod (?)
- ~~Maybe multi-stage sites part (?)~~
- ~~General cleanup and better semantic namings~~ 
- ~~entryPoint configs for apps~~ 
- ~~configs for site~~ 
- ~~pluginSlots equivalent~~
- ~~patch locations~~
- final readme with the details after we have everything else

## How to add a frontendapp
In order to mark something as a frontendbase app you need a plugin that looks like:

```py
from tutormfe.hooks import FRONTEND_APPS

@FRONTEND_APPS.add()
def _add_frontend_apps(apps):
    apps["learner-dashboard"] = {
    "appEntryPoints": {
            "packageName": "@openedx/frontend-app-learner-dashboard",
            "packageVersion": "^1.0.0-alpha",
            "styles": ["app.scss"],
            "components": ["learnerDashboardApp"],
        },
    }
    apps["authn"] = {
    "appEntryPoints": {
            "packageName": "@openedx/frontend-app-authn",
            "packageVersion": "^1.0.0-alpha",
            "styles": ["app.scss"],
            "components": ["authnApp"],
        },
    }
    apps["instructor"] = {
    "appEntryPoints": {
            "packageName": "@openedx/frontend-app-instruct",
            "packageVersion": "^1.0.0-alpha",
            "styles": ["app.scss"],
            "components": ["instructApp"],
        },
    } 
    return apps
```

and if you need some of those to be manually build and installed in the frontend-site:

```py
@FRONTEND_APPS.add()
def _add_frontend_apps(apps):
    apps["learner-dashboard"] = {
        "repository": "https://github.com/arbrandes/frontend-app-learner-dashboard.git",
        "version": "workspaces-dev",
        "appEntryPoints": {
            "packageName": "@openedx/frontend-app-learner-dashboard",
            "packageVersion": "^1.0.0-alpha",
            "styles": ["app.scss"],
            "components": ["learnerDashboardApp"],
        },
    }
    apps["authn"] = {
        "repository": "https://github.com/arbrandes/frontend-app-authn.git",
        "version": "workspaces-dev",
        "appEntryPoints": {
            "packageName": "@openedx/frontend-app-authn",
            "packageVersion": "^1.0.0-alpha",
            "styles": ["app.scss"],
            "components": ["authnApp"],
        },
    }

    return apps
```

When no `repository`and `version`are specified nothing will be added to the `packages/` folder for that frontend-app so npm will try to fetch them from the registry

Any app that it's on this list will be considered a fronend-app so when Caddy shows the content for it, it will show the one on frontend-site instead of the normal app.

By default there's going to be a frontend-site that it's build from files in the tutor-mfe plugin (everything under `tutormfe/templates/mfe/build/mfe/frontend-site`)

if the operator wants to add a new site or substitute the default one it can be done like:

```py
@FRONTEND_SITES.add()
def _add_frontend_base_apps(sites):
    sites['default'] = {
      "repository": "https://github.com/openedx/frontend-site-custom",
      "version": "main"
      "port": "8080"
    }
    return sites
```

The structure is the same as adding an MFE the only thing to take in account is that if you want to add a new site with a different name than default you also need to specify which frontend apps will live there so Caddy knows that it should serve those files

```py
@FRONTEND_SITES.add()
def _add_frontend_base_apps(sites):
    sites['new-site'] = {
      "repository": "https://github.com/openedx/frontend-site-custom",
      "version": "main"
      "port": "8082"
    }
    return sites

@FRONTEND_APPS.add()
def _add_frontend_apps(apps):
    apps["learner-dashboard"] = {
        "repository": "https://github.com/openedx/frontend-app-learner-dashboard.git",
        "version": "frontend-base",
        "site": "new-site"
    }
    return apps
```


In case that further customization is required for the a frontensite the full config looks like:

```py
@FRONTEND_SITES.add()
def _add_frontend_base_apps(sites):
    sites['default'] = {
        "repository": "local",
        "port": 8080,
        "siteConfig": {
            "siteId": "tutor-frontend-site",
            "siteName": "Frontend Template Site",
            "accessTokenCookieName": "edx-jwt-cookie-header-payload",
            "redirectRoleId": "org.openedx.frontend.role.dashboard",
            "frontendBaseVersion": "^1.0.0-alpha",
            "paragonVersion": "^23", 
            "externalRoutes": [
                {
                    "role": "org.openedx.frontend.role.profile",
                    "url": ":1995/profile/",
                },
                {
                    "role": "org.openedx.frontend.role.account",
                    "url": ":1997/account/",
                },
                {
                    "role": "org.openedx.frontend.role.logout",
                    "url": ":8000/logout",
                },
            ],
        },
    },

    return sites
```

### Config values reference 

| value | description | default |
|--------|--------|--------|
| siteId | direct equivalent of `siteId` inside site.config.xx.tsx | `'tutor-frontend-site'`|
| siteName | direct equivalent of `siteName` inside site.config.xx.tsx | `'Frontend site'`|
| accessTokenCookieName | direct equivalent of `accessTokenCookieName` inside site.config.xx.tsx | `'edx-jwt-cookie-header-payload'`|
| redirectRoleId | role id to be used to readirect navigation to the default root route when someone access `http://apps.local.openedx.io:8080/` (root route) | `''` the default would fail and throw a 404 so a role needs to always be defined and pointing to the proper place |
| frontendBaseVersion | allows the configuration of a custom version of frontend-base or assign an [alias](https://docs.npmjs.com/cli/v8/using-npm/package-spec#aliases) for it | `'tutor-frontend-site'`|
| paragonVersion | allows the configuration of a custom version of paragon or assign an [alias](https://docs.npmjs.com/cli/v8/using-npm/package-spec#aliases) for it | `'tutor-frontend-site'`|
| externalRoutes | allows the configuration of the external routes to be configured at site.config.xx.tsx | `[]`|


## Front end slots
Given the current architecture of a frontendbase the slots part has been dramatically simplified and made more powerful, so for complex slot situations you can always create an app based on the [template-site](https://github.com/openedx/frontend-template-site) and just export the slots you require, but if you need a single file plugin / config for a slot then we get the new `@FRONTEND_SLOTS`

The usage will be similar to the current `@PLUGIN_SLOTS` but way more simplified, ex:

```py
@FRONTEND_SLOTS.add()
def _add_app_slots(app_slots):
    app_slots.append(
        (
            "org.openedx.frontend.slot.header.primaryLinks.v1",
            """
            {
                slotId: 'org.openedx.frontend.slot.header.primaryLinks.v1',
                id: 'org.openedx.frontend.widget.learnerDashboard.headerLinkDiscover.v999',
                op: WidgetOperationTypes.APPEND,
                element: (
                    <a href="https://github.com/openedx/frontend-base/blob/main/docs/decisions/0009-slot-naming-and-lifecycle.rst"
                    className="nav-link"
                    >
                    Discover the power of slots!</a>
                )
            }
            """,
        )
    )
    return app_slots
```

This is a widget that it's configured to add be added at the `org.openedx.frontend.slot.header.primaryLinks.v1'` ID which exists in the header and Adds a new link next to whichever is already there

<img width="666" height="173" alt="image" src="https://github.com/user-attachments/assets/36cb96be-4c34-40a8-b269-5aceb74569d3" />

The main difference is that  we no longer need the app name, just the slotID (and currently it's not used...) and the slot config, any slot configured here will be configured in a mini-app which just makes the slots available for the build  `slots.tsx`


## New patches
Some new patches were introduced to cover previous available functionality that may be used to extend frontend app functionality

| name | location | description |
|--------|--------|--------|
| frontend-site-dockerfile-pre-npm-install | Dockerfile | Runs inmediatly before site npm install |
| frontend-site-dockerfile-post-npm-install | Dockerfile | Runs inmediatly after site npm install |
| frontend-site-dockerfile-pre-npm-build | Dockerfile | Runs inmediatly before site npm run build |
| frontend-site-dockerfile-post-npm-build | Dockerfile | Runs inmediatly after site npm run build |
| frontend-slots-env-config-buildtime-imports | slotsApp.tsx | Lives before the definition fo the slotsApp |
