### PR TITLE
fix: use ENABLE_CATALOG_MICROFRONTEND as direct setting instead of FEATURES

### DIFF
--- a/tutormfe/patches/openedx-lms-common-settings
+++ b/tutormfe/patches/openedx-lms-common-settings
@@ -9,7 +9,7 @@ MFE_CONFIG_API_CACHE_TIMEOUT = 1
 FEATURES['ENABLE_AUTHN_MICROFRONTEND'] = True
 {% endif %}
 {% if get_mfe("catalog") %}
-FEATURES['ENABLE_CATALOG_MICROFRONTEND'] = True
+ENABLE_CATALOG_MICROFRONTEND = True
 {% endif %}
 {% if get_mfe("communications") %}
 FEATURES['ENABLE_NEW_BULK_EMAIL_EXPERIENCE'] = True


### PR DESCRIPTION
## Summary

- Replace `FEATURES['ENABLE_CATALOG_MICROFRONTEND'] = True` with `ENABLE_CATALOG_MICROFRONTEND = True` in the LMS common settings patch

## Context

The `FEATURES` dictionary is being deprecated in openedx-platform as part of the platform settings simplification effort. The catalog MFE support in tutor-mfe (added in #259) predates this change and still uses the old `FEATURES` dict form.

Meanwhile, openedx-platform has already moved to looking up `ENABLE_CATALOG_MICROFRONTEND` as a direct Django setting:
- Review comment requesting the change: https://github.com/openedx/openedx-platform/pull/37342#discussion_r2382912634
- Fix commit in openedx-platform: https://github.com/openedx/openedx-platform/commit/b448b0fe69982e093f84b0d8af8c54718d963a08

The frontend-app-catalog README also uses the direct setting form in its [Tutor installation example](https://github.com/openedx/frontend-app-catalog/tree/master?tab=readme-ov-file#installing-in-tutor).

### Related links
- FEATURES flattening PR: https://github.com/openedx/openedx-platform/pull/37067
- DEPR: FeaturesProxy: https://github.com/openedx/openedx-platform/issues/37345
- DEPR: FEATURES dictionary: https://github.com/openedx/openedx-platform/issues/37396
- Catalog MFE PR (tutor-mfe): https://github.com/overhangio/tutor-mfe/pull/259
- Catalog MFE link generation PR: https://github.com/openedx/openedx-platform/pull/37342

## Test plan

- [x] Verify the catalog MFE is enabled correctly with the new setting form
- [x] Confirm `ENABLE_CATALOG_MICROFRONTEND` is accessible as a top-level Django setting in LMS

🤖 Generated with [Claude Code](https://claude.com/claude-code)