### PR TITLE
feat: add INJECTED_SCRIPTS hook for MFE script injection

### DIFF
--- a/tutormfe/hooks.py
+++ b/tutormfe/hooks.py
@@ -15,3 +15,5 @@ MFE_ATTRS_TYPE = t.Dict[t.Literal["repository", "port", "version"], t.Union["str
 MFE_APPS: Filter[dict[str, MFE_ATTRS_TYPE], []] = Filter()
 
 PLUGIN_SLOTS: Filter[list[tuple[str, str, str]], []] = Filter()
+
+INJECTED_SCRIPTS: Filter[list[tuple[str, str, str]], []] = Filter()

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -13,7 +13,7 @@ from tutor.hooks import priorities
 from tutor.types import Config, get_typed
 
 from .__about__ import __version__
-from .hooks import MFE_APPS, MFE_ATTRS_TYPE, PLUGIN_SLOTS
+from .hooks import MFE_APPS, MFE_ATTRS_TYPE, PLUGIN_SLOTS, INJECTED_SCRIPTS
 
 # Handle version suffix in main mode, just like tutor core
 if __version_suffix__:
@@ -138,6 +138,22 @@ def iter_plugin_slots(mfe_name: str) -> t.Iterable[tuple[str, str]]:
     """
     yield from get_plugin_slots(mfe_name)
 
+@tutor_hooks.lru_cache
+def get_injected_scripts(mfe_name: str) -> list[tuple[str, str]]:
+    """
+    This function is cached for performance.
+    """
+    return [i[-2:] for i in INJECTED_SCRIPTS.iterate() if i[0] == mfe_name]
+
+
+def iter_injected_scripts(mfe_name: str) -> t.Iterable[tuple[str, str]]:
+    """
+    Yield:
+
+        (script_name, script_content)
+    """
+    yield from get_injected_scripts(mfe_name)
+
 
 def is_mfe_enabled(mfe_name: str) -> bool:
     return mfe_name in get_mfes()
@@ -155,6 +171,7 @@ tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
         ("iter_plugin_slots", iter_plugin_slots),
         ("is_mfe_enabled", is_mfe_enabled),
         ("MFEMountData", MFEMountData),
+        ("iter_injected_scripts", iter_injected_scripts),
     ]
 )
 

--- a/tutormfe/templates/mfe/build/mfe/env.config.jsx
+++ b/tutormfe/templates/mfe/build/mfe/env.config.jsx
@@ -15,8 +15,22 @@ function addPlugins(config, slot_name, plugins) {
 
 async function setConfig () {
   let config = {
-    pluginSlots: {}
+    pluginSlots: {},
+    injectedScripts: []
   };
+
+  // Inject scripts here since FPF is not guaranteed to be present in all MFEs
+  {%- for script_name, script_content in iter_injected_scripts("all") %}
+  config.injectedScripts.push({{ script_content }});
+  {%- endfor %}
+
+  {%- for app_name, _ in iter_mfes() %}
+  if (process.env.APP_ID == '{{ app_name }}') {
+    {%- for script_name, script_content in iter_injected_scripts(app_name) %}
+    config.injectedScripts.push({{ script_content }});
+    {%- endfor %}
+  }
+  {%- endfor %}
 
   try {
     /* We can't assume FPF exists, as it's not declared as a dependency in all


### PR DESCRIPTION
Creates a parallel pipeline to the `PLUGIN_SLOTS` pattern specifically for injecting raw JavaScript classes into `env.config.jsx`. Prevents injected scripts from clobbering default external scripts or React components by injecting before the `PLUGIN_SLOTS` mechanism which uses FPF (frontend-plugin-framework) that this slot mechanism does not need.

### How to test this PR
To verify the injection pipeline works, you can drop this simple test plugin into your local environment.

```python
from tutormfe.hooks import INJECTED_SCRIPTS

test_content = """
class TestScriptLoader {
  constructor(data) { this.data = data; }
  loadScript() {
    console.log("Test Script injected successfully from Tutor!");
  }
}
"""

# Injecting into the 'authn' MFE for testing
INJECTED_SCRIPTS.add_item(
  ("authn", "test_script", test_content)
)
```
Install, enable and save config it:
```
tutor plugins install test_script.py
tutor plugins enable test_script
tutor config save
```
Check the generated file at `env/plugins/mfe/build/mfe/env.config.jsx` to see the script appended, or copy to the mounted MFE's directory and run the MFE to see the console in dev tools.