### PR TITLE
feat: add EXTERNAL_SCRIPTS hook for configuring MFE external scripts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -534,6 +534,87 @@ For instance:
 Refer to the `patch catalog <#template-patch-catalog>`_ below for more details.
 
 
+Configuring External Scripts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+External scripts are a frontend-platform feature that allows script loaders to be configured via ``env.config.jsx``. A loader is a JavaScript class with a ``constructor({ config })`` and a ``loadScript()`` method. This plugin provides the ``EXTERNAL_SCRIPTS`` hook so that Tutor plugins can register loaders for MFEs without resorting to patches.
+
+The hook works similarly to ``PLUGIN_SLOTS``. Each item is a tuple of ``(mfe_name, loader_class)``, where ``mfe_name`` is either ``"all"`` (to apply to every MFE) or the name of a specific MFE, and ``loader_class`` is the name of a loader class that will be added to the ``externalScripts`` config array. Frontend-platform instantiates the class at runtime and passes the MFE's runtime config to its constructor.
+
+For instance, to inject a third-party ``<script>`` tag across all MFEs, define a loader directly in ``env.config.jsx``:
+
+.. code-block:: python
+
+    from tutormfe.hooks import EXTERNAL_SCRIPTS
+    from tutor import hooks
+
+    hooks.Filters.ENV_PATCHES.add_item(
+        (
+            "mfe-env-config-buildtime-definitions",
+            """
+    class CustomScriptLoader {
+      constructor({ config }) {
+        this.config = config;
+      }
+
+      loadScript() {
+        if (!this.config.CUSTOM_SCRIPT_URL) {
+          return;
+        }
+        const script = document.createElement('script');
+        script.id = 'custom-script';
+        script.src = this.config.CUSTOM_SCRIPT_URL;
+        document.head.appendChild(script);
+      }
+    }
+    """,
+        )
+    )
+
+    EXTERNAL_SCRIPTS.add_items([
+        (
+            "all",
+            "CustomScriptLoader",
+        ),
+    ])
+
+The ``CustomScriptLoader`` class is defined via the ``mfe-env-config-buildtime-definitions`` patch, and the ``EXTERNAL_SCRIPTS`` hook wires it into the configuration. Frontend-platform instantiates the class at runtime and passes the MFE's runtime config to the constructor, so the loader can read any key from ``MFE_CONFIG`` (here, ``CUSTOM_SCRIPT_URL``, which you would set via the ``mfe-lms-common-settings`` patch or equivalent). The built-in ``GoogleAnalyticsLoader`` in ``@openedx/frontend-platform/scripts`` follows the same pattern with ``config.GOOGLE_ANALYTICS_4_ID`` - you can import it with the ``mfe-env-config-buildtime-imports`` patch and use it with ``EXTERNAL_SCRIPTS`` in the same way.
+
+You can also target a specific MFE. For example, to load a custom script only on the learning MFE:
+
+.. code-block:: python
+
+    from tutormfe.hooks import EXTERNAL_SCRIPTS
+    from tutor import hooks
+
+    hooks.Filters.ENV_PATCHES.add_item(
+        (
+            "mfe-dockerfile-post-npm-install",
+            """
+    RUN npm install @myorg/custom-script-loader
+    """,
+        )
+    )
+
+    hooks.Filters.ENV_PATCHES.add_item(
+        (
+            "mfe-env-config-buildtime-imports",
+            """
+    import { CustomScriptLoader } from '@myorg/custom-script-loader';
+    """,
+        )
+    )
+
+    EXTERNAL_SCRIPTS.add_items([
+        (
+            "learning",
+            "CustomScriptLoader",
+        ),
+    ])
+
+Note that if no external scripts are configured, the ``externalScripts`` key is not set in the config at all, so any MFE-level defaults are preserved.
+
+
 Hosting extra static files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/changelog.d/20260415_external_scripts.md
+++ b/changelog.d/20260415_external_scripts.md
@@ -1,0 +1,1 @@
+- [Feature] Add `EXTERNAL_SCRIPTS` hook for configuring MFE external scripts via `env.config.jsx`. (by @arbrandes)

--- a/tutormfe/hooks.py
+++ b/tutormfe/hooks.py
@@ -19,3 +19,5 @@ MFE_APPS: Filter[dict[str, MFE_ATTRS_TYPE], []] = Filter()
 CORE_PLUGINS: Filter[dict[str, CORE_PLUGIN_ATTRS_TYPE], []] = Filter()
 
 PLUGIN_SLOTS: Filter[list[tuple[str, str, str]], []] = Filter()
+
+EXTERNAL_SCRIPTS: Filter[list[tuple[str, str]], []] = Filter()

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -16,6 +16,7 @@ from .__about__ import __version__
 from .hooks import (
     CORE_PLUGIN_ATTRS_TYPE,
     CORE_PLUGINS,
+    EXTERNAL_SCRIPTS,
     MFE_APPS,
     MFE_ATTRS_TYPE,
     PLUGIN_SLOTS,
@@ -171,6 +172,14 @@ def get_plugin_slots(mfe_name: str) -> list[tuple[str, str]]:
     return [i[-2:] for i in PLUGIN_SLOTS.iterate() if i[0] == mfe_name]
 
 
+@tutor_hooks.lru_cache
+def get_external_scripts(mfe_name: str) -> list[str]:
+    """
+    This function is cached for performance.
+    """
+    return [i[-1] for i in EXTERNAL_SCRIPTS.iterate() if i[0] == mfe_name]
+
+
 def iter_mfes() -> t.Iterable[tuple[str, MFE_ATTRS_TYPE]]:
     """
     Yield:
@@ -189,6 +198,15 @@ def iter_plugin_slots(mfe_name: str) -> t.Iterable[tuple[str, str]]:
     yield from get_plugin_slots(mfe_name)
 
 
+def iter_external_scripts(mfe_name: str) -> t.Iterable[str]:
+    """
+    Yield:
+
+        (script_config)
+    """
+    yield from get_external_scripts(mfe_name)
+
+
 def is_mfe_enabled(mfe_name: str) -> bool:
     return mfe_name in get_mfes()
 
@@ -203,6 +221,7 @@ tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
         ("get_mfe", get_mfe),
         ("iter_mfes", iter_mfes),
         ("iter_plugin_slots", iter_plugin_slots),
+        ("iter_external_scripts", iter_external_scripts),
         ("is_mfe_enabled", is_mfe_enabled),
         ("iter_core_plugins", iter_core_plugins),
         ("is_core_plugin_enabled", is_core_plugin_enabled),

--- a/tutormfe/templates/mfe/build/mfe/env.config.jsx
+++ b/tutormfe/templates/mfe/build/mfe/env.config.jsx
@@ -11,6 +11,14 @@ function addPlugins(config, slot_name, plugins) {
   config.pluginSlots[slot_name].plugins.push(...plugins);
 }
 
+function addExternalScripts(config, scripts) {
+  if (!config.externalScripts) {
+    config.externalScripts = [];
+  }
+
+  config.externalScripts.push(...scripts);
+}
+
 {{- patch("mfe-env-config-buildtime-definitions") }}
 
 async function setConfig () {
@@ -67,6 +75,18 @@ async function setConfig () {
 
     {{- patch("mfe-env-config-runtime-final") }}
   } catch (err) { console.error("env.config.jsx failed to apply: ", err);}
+
+  {%- for script_config in iter_external_scripts("all") %}
+  addExternalScripts(config, [{{ script_config }}]);
+  {%- endfor %}
+
+  {%- for app_name, _ in iter_mfes() %}
+  if (process.env.APP_ID == '{{ app_name }}') {
+    {%- for script_config in iter_external_scripts(app_name) %}
+    addExternalScripts(config, [{{ script_config }}]);
+    {%- endfor %}
+  }
+  {%- endfor %}
 
   return config;
 }


### PR DESCRIPTION
### Description

frontend-platform recently made `externalScripts` configurable via `env.config.js`, following the same pattern used for `loggingService`, `analyticsService`, and `authService`. This allows script loaders (such as `GoogleAnalyticsLoader`) to be declared in configuration rather than hardcoded in `initialize()`.

This PR adds an `EXTERNAL_SCRIPTS` hook to tutor-mfe so that Tutor plugins can register external scripts without resorting to patches. The hook follows the same pattern as `PLUGIN_SLOTS`: each item is a `(mfe_name, script_config)` tuple, where `mfe_name` is `"all"` or a specific MFE name, and `script_config` is the JavaScript expression to add to the `externalScripts` config array.

In the `env.config.jsx` template, external scripts are wired up outside the frontend-plugin-framework try/catch block, since they don't depend on FPF. The `externalScripts` key is only set when scripts are actually configured, so MFE-level defaults are preserved when no scripts are registered.

Depends on https://github.com/openedx/frontend-platform/pull/876.
### Testing

**Baseline: no scripts registered.** With a stock `mfe` plugin, run `tutor config save` and inspect the rendered `env/build/mfe/apps/<app>/env.config.jsx`. Verify that no `addExternalScripts(...)` calls are emitted and that `config.externalScripts` is never assigned, so any MFE-level defaults remain untouched.

**All-MFE registration.** Create a throwaway Tutor plugin at `$(tutor plugins printroot)/fakeloader.py` with the following contents:

```python
from tutor import hooks
from tutormfe.hooks import EXTERNAL_SCRIPTS

hooks.Filters.ENV_PATCHES.add_item(
    (
        "mfe-env-config-buildtime-definitions",
        """
class FakeLoaderAll {
  constructor() {}
  loadScript() {
    console.log('FakeLoaderAll ran');
  }
}
""",
    )
)

EXTERNAL_SCRIPTS.add_items([
    ("all", "FakeLoaderAll"),
])
```

Enable it with `tutor plugins enable fakeloader`, then run `tutor config save` and inspect `env/build/mfe/apps/<app>/env.config.jsx` for any MFE. Confirm `FakeLoaderAll` is defined in the buildtime section and that `addExternalScripts(config, [FakeLoaderAll]);` appears outside any `APP_ID` guard. Run `tutor dev launch` (or your usual dev flow), load an MFE that is running the latest version of frontend-platform (check https://github.com/openedx/public-engineering/issues/505) in a browser, and confirm `FakeLoaderAll ran` is logged to the console on both.

**Per-MFE registration.** Extend the same plugin file with a second loader targeted at a single MFE:

```python
hooks.Filters.ENV_PATCHES.add_item(
    (
        "mfe-env-config-buildtime-definitions",
        """
class FakeLoaderLearning {
  constructor() {}
  loadScript() {
    console.log('FakeLoaderLearning ran');
  }
}
""",
    )
)

EXTERNAL_SCRIPTS.add_items([
    ("learning", "FakeLoaderLearning"),
])
```

Re-run `tutor config save` and confirm the learning MFE's `env.config.jsx` wraps the `FakeLoaderLearning` call in `if (process.env.APP_ID == 'learning')`, while other MFEs do not get that call at all. Reload the learning MFE and verify both `FakeLoaderAll ran` and `FakeLoaderLearning ran` appear in the console; reload authn and verify only `FakeLoaderAll ran` appears.

**Plugin disabled.** Run `tutor plugins disable fakeloader && tutor config save` and confirm both the loader class definitions and the `addExternalScripts` calls disappear from the rendered templates, and that `config.externalScripts` is no longer assigned.

### LLM usage notice

Built with assistance from Claude.