### PR TITLE
fix: bump Node to 24.14.1

### DIFF
--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # https://hub.docker.com/_/node/tags
-FROM docker.io/node:24.11.0-bullseye-slim AS base
+FROM docker.io/node:24.14.1-bullseye-slim AS base
 
 RUN apt update \
   && apt install -y git \


### PR DESCRIPTION
### Description

Bumps the Node version used in the MFE Dockerfile to 24.14.1. Recent `package-lock.json` regenerations (notably in `frontend-app-discussion`) require a newer Node than the currently pinned version.