### PR TITLE
Revert "feat: add CORE_PLUGINS hook and bundle the notifications tray"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,10 +18,6 @@ In addition, this plugin comes with a few MFEs which are enabled by default:
 - `Profile <https://github.com/openedx/frontend-app-profile/>`__
 - `Catalog <https://github.com/openedx/frontend-app-catalog/>`__
 
-In addition, this plugin bundles a number of "core plugins": frontend plugin packages injected into the MFEs above via the plugin slot framework. The following core plugins are enabled by default:
-
-- `Notifications <https://github.com/openedx/frontend-plugin-notifications/>`__ (a notifications tray in the MFE headers)
-
 Instructions for using each of these MFEs are given below.
 
 Installation
@@ -185,30 +181,6 @@ To disable an existing MFE, remove the corresponding entry from the ``MFE_APPS``
         mfes.pop("account")
         mfes.pop("profile")
         return mfes
-
-Core plugins
-~~~~~~~~~~~~
-
-Core plugins are bundled frontend plugin packages that ship with tutor-mfe and are injected into the MFEs via the plugin slot framework. They are enabled by default, but operators can disable any of them by popping the corresponding entry from the ``CORE_PLUGINS`` filter, symmetrically to how ``MFE_APPS`` works.
-
-The following core plugins are currently bundled:
-
-- ``notifications``: the `notifications tray <https://github.com/openedx/frontend-plugin-notifications/>`__, added to the learning and Studio headers. Its behaviour can be tuned with three configuration settings:
-
-  - ``NOTIFICATIONS_DEFAULT_FROM_EMAIL`` (default: inherits from ``CONTACT_EMAIL``): the sender address used by notification emails.
-  - ``NOTIFICATIONS_ENABLE_SHOW_EMAIL_CHANNEL`` (default: ``True``): whether to show the email channel in the notification preferences UI.
-  - ``NOTIFICATIONS_ENABLE_SHOW_PUSH_CHANNEL`` (default: ``False``): whether to show the push channel in the notification preferences UI.
-
-To disable the notifications tray (or any other core plugin), add a Tutor plugin with:
-
-.. code-block:: python
-
-    from tutormfe.hooks import CORE_PLUGINS
-
-    @CORE_PLUGINS.add()
-    def _disable_notifications(plugins):
-        plugins.pop("notifications", None)
-        return plugins
 
 Using custom translations to your MFEs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/changelog.d/20260420_core_plugins_notifications.md
+++ b/changelog.d/20260420_core_plugins_notifications.md
@@ -1,2 +1,0 @@
-- [Feature] Introduce the ``CORE_PLUGINS`` filter, a new extension point for bundled frontend plugin packages that ship with tutor-mfe. Operators can disable any core plugin by popping its name from the filter, symmetrically to how ``MFE_APPS`` works. (by @arbrandes)
-- [Feature] Bundle the notifications tray (``@edx/frontend-plugin-notifications``) as the first core plugin, enabled by default. This replaces the need for a standalone ``tutor-contrib-platform-notifications`` plugin. (by @arbrandes)

--- a/tutormfe/hooks.py
+++ b/tutormfe/hooks.py
@@ -12,11 +12,7 @@ from tutor.core.hooks import Filter
 
 MFE_ATTRS_TYPE = t.Dict[t.Literal["repository", "port", "version"], t.Union["str", int]]
 
-CORE_PLUGIN_ATTRS_TYPE = t.Dict[t.Literal["npm_package", "npm_version"], str]
-
 MFE_APPS: Filter[dict[str, MFE_ATTRS_TYPE], []] = Filter()
-
-CORE_PLUGINS: Filter[dict[str, CORE_PLUGIN_ATTRS_TYPE], []] = Filter()
 
 PLUGIN_SLOTS: Filter[list[tuple[str, str, str]], []] = Filter()
 

--- a/tutormfe/patches/lms-env
+++ b/tutormfe/patches/lms-env
@@ -1,3 +1,0 @@
-{% if is_core_plugin_enabled("notifications") %}
-NOTIFICATIONS_DEFAULT_FROM_EMAIL: '{{ NOTIFICATIONS_DEFAULT_FROM_EMAIL }}'
-{% endif %}

--- a/tutormfe/patches/openedx-common-settings
+++ b/tutormfe/patches/openedx-common-settings
@@ -1,3 +1,0 @@
-{% if is_core_plugin_enabled("notifications") %}
-NOTIFICATIONS_DEFAULT_FROM_EMAIL = ENV_TOKENS.get("NOTIFICATIONS_DEFAULT_FROM_EMAIL", ENV_TOKENS["CONTACT_EMAIL"])
-{% endif %}

--- a/tutormfe/patches/openedx-lms-production-settings
+++ b/tutormfe/patches/openedx-lms-production-settings
@@ -94,8 +94,3 @@ CSRF_TRUSTED_ORIGINS.append("{% if ENABLE_HTTPS %}https://{% else %}http://{% en
 
 {{ patch("mfe-lms-common-settings") }}
 {{ patch("mfe-lms-production-settings") }}
-
-{% if is_core_plugin_enabled("notifications") %}
-MFE_CONFIG["SHOW_EMAIL_CHANNEL"] = {{ NOTIFICATIONS_ENABLE_SHOW_EMAIL_CHANNEL }}
-MFE_CONFIG["SHOW_PUSH_CHANNEL"] = {{ NOTIFICATIONS_ENABLE_SHOW_PUSH_CHANNEL }}
-{% endif %}

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -14,8 +14,6 @@ from tutor.types import Config, get_typed
 
 from .__about__ import __version__
 from .hooks import (
-    CORE_PLUGIN_ATTRS_TYPE,
-    CORE_PLUGINS,
     EXTERNAL_SCRIPTS,
     MFE_APPS,
     MFE_ATTRS_TYPE,
@@ -98,52 +96,12 @@ def _add_core_mfe_apps(apps: dict[str, MFE_ATTRS_TYPE]) -> dict[str, MFE_ATTRS_T
     return apps
 
 
-# Core plugins are bundled frontend plugin packages (and associated wiring) that ship
-# enabled by default. Operators can disable any of them by popping the name from the
-# CORE_PLUGINS filter, symmetric to how MFE_APPS works.
-DEFAULT_CORE_PLUGINS: dict[str, CORE_PLUGIN_ATTRS_TYPE] = {
-    "notifications": {
-        "npm_package": "@edx/frontend-plugin-notifications",
-        "npm_version": "^2.0.3",
-    },
-}
-
-
-@CORE_PLUGINS.add(priority=tutor_hooks.priorities.HIGH)
-def _add_default_core_plugins(
-    plugins: dict[str, CORE_PLUGIN_ATTRS_TYPE],
-) -> dict[str, CORE_PLUGIN_ATTRS_TYPE]:
-    plugins.update(DEFAULT_CORE_PLUGINS)
-    return plugins
-
-
 @tutor_hooks.lru_cache
 def get_mfes() -> dict[str, MFE_ATTRS_TYPE]:
     """
     This function is cached for performance.
     """
     return MFE_APPS.apply({})
-
-
-@tutor_hooks.lru_cache
-def get_core_plugins() -> dict[str, CORE_PLUGIN_ATTRS_TYPE]:
-    """
-    This function is cached for performance.
-    """
-    return CORE_PLUGINS.apply({})
-
-
-def iter_core_plugins() -> t.Iterable[tuple[str, CORE_PLUGIN_ATTRS_TYPE]]:
-    """
-    Yield:
-
-        (name, dict)
-    """
-    yield from get_core_plugins().items()
-
-
-def is_core_plugin_enabled(name: str) -> bool:
-    return name in get_core_plugins()
 
 
 class MFEMountData:
@@ -223,8 +181,6 @@ tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
         ("iter_plugin_slots", iter_plugin_slots),
         ("iter_external_scripts", iter_external_scripts),
         ("is_mfe_enabled", is_mfe_enabled),
-        ("iter_core_plugins", iter_core_plugins),
-        ("is_core_plugin_enabled", is_core_plugin_enabled),
         ("MFEMountData", MFEMountData),
     ]
 )
@@ -392,16 +348,6 @@ tutor_hooks.Filters.CONFIG_UNIQUE.add_items(
 )
 tutor_hooks.Filters.CONFIG_OVERRIDES.add_items(
     list(config.get("overrides", {}).items())
-)
-
-# Notifications core plugin settings. Registered unconditionally: harmless if the
-# plugin is disabled, since nothing will consume them.
-tutor_hooks.Filters.CONFIG_DEFAULTS.add_items(
-    [
-        ("NOTIFICATIONS_ENABLE_SHOW_EMAIL_CHANNEL", True),
-        ("NOTIFICATIONS_ENABLE_SHOW_PUSH_CHANNEL", False),
-        ("NOTIFICATIONS_DEFAULT_FROM_EMAIL", "{{ CONTACT_EMAIL }}"),
-    ]
 )
 
 

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -46,9 +46,6 @@ ENV CPPFLAGS=-DPNG_ARM_NEON_OPT=0
 {#- We define this environment variable to bypass an issue with the installation of pact https://github.com/pact-foundation/pact-js-core/issues/264 #}
 ENV PACT_SKIP_BINARY_INSTALL=true
 RUN --mount=type=cache,target=/root/.npm,sharing=shared npm clean-install --no-audit --no-fund --registry=$NPM_REGISTRY
-{%- for _plugin_name, plugin in iter_core_plugins() %}
-RUN --mount=type=cache,target=/root/.npm,sharing=shared npm install --no-audit --no-fund --registry=$NPM_REGISTRY {{ plugin["npm_package"] }}@{{ plugin["npm_version"] }}
-{%- endfor %}
 {{ patch("mfe-dockerfile-post-npm-install") }}
 {{ patch("mfe-dockerfile-post-npm-install-{}".format(app_name)) }}
 COPY --from={{ app_name }}-src / /openedx/app

--- a/tutormfe/templates/mfe/build/mfe/env.config.jsx
+++ b/tutormfe/templates/mfe/build/mfe/env.config.jsx
@@ -33,31 +33,8 @@ async function setConfig () {
      * needs to be inside the `try{}` block.
      */
     const { DIRECT_PLUGIN, PLUGIN_OPERATIONS } = await import('@openedx/frontend-plugin-framework');
-    {%- if is_core_plugin_enabled("notifications") %}
-    const { NotificationsTray } = await import('@edx/frontend-plugin-notifications');
-    {%- endif %}
 
     {{- patch("mfe-env-config-runtime-definitions") }}
-
-    {%- if is_core_plugin_enabled("notifications") %}
-    {%- for slot_name in [
-      "org.openedx.frontend.layout.header_desktop_secondary_menu.v1",
-      "org.openedx.frontend.layout.header_learning_help.v1",
-      "org.openedx.frontend.layout.studio_header_search_button_slot.v1",
-    ] %}
-    addPlugins(config, '{{ slot_name }}', [
-      {
-        op: PLUGIN_OPERATIONS.Insert,
-        widget: {
-          id: 'notification-drawer-widget',
-          priority: 10,
-          type: DIRECT_PLUGIN,
-          RenderWidget: NotificationsTray,
-        },
-      },
-    ]);
-    {%- endfor %}
-    {%- endif %}
 
     {%- for slot_name, plugin_config in iter_plugin_slots("all") %}
     addPlugins(config, '{{ slot_name }}', [{{ plugin_config }}]);


### PR DESCRIPTION
### Description

Reverts 84368d9 ("feat: add CORE_PLUGINS hook and bundle the notifications tray"), which introduced a `CORE_PLUGINS` filter and bundled the notifications tray as the first core plugin.

The rationale for this revert is that openedx/frontend-component-header#663 is now making the notifications tray available out-of-the-box via a `HeaderNotificationsSlot`, removing the need for a separate bundled plugin in tutor-mfe.

### LLM usage notice

Built with assistance from Claude.