### PR TITLE
ci: deploy admin-console-dev image to docker hub

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 variables:
     TUTOR_PLUGIN: mfe
-    TUTOR_IMAGES: mfe account-dev authn-dev authoring-dev communications-dev discussions-dev gradebook-dev learner-dashboard-dev learning-dev ora-grading-dev profile-dev
+    TUTOR_IMAGES: mfe account-dev admin-console-dev authn-dev authoring-dev communications-dev discussions-dev gradebook-dev learner-dashboard-dev learning-dev ora-grading-dev profile-dev
     TUTOR_PYPI_PACKAGE: tutor-mfe
     GITHUB_REPO: overhangio/tutor-mfe
 


### PR DESCRIPTION
The admin-console-dev was not being pushed to DockerHub, thus resulting in errors during `tutor images pull all`.