### PR TITLE
Use stable frontend-base and app releases

### DIFF
--- a/changelog.d/20260710_000000_adolfo_stable_frontend_base.md
+++ b/changelog.d/20260710_000000_adolfo_stable_frontend_base.md
@@ -1,0 +1,1 @@
+- [Improvement] Bump frontend-base, frontend-base-compat, and the core frontend apps (`authn`, `learner-dashboard`, `instructor-dashboard`, `notifications`) from alpha to their stable `1.0.0`/`3.0.0` releases. (by @arbrandes)

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -118,22 +118,22 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
 CORE_FRONTEND_APPS: dict[str, FRONTEND_APP_ATTRS_TYPE] = {
     "authn": {
         "npm_package": "@openedx/frontend-app-authn",
-        "npm_version": "^1.0.0-alpha || 0.0.0-dev",
+        "npm_version": "^1.0.0 || 0.0.0-dev",
         "enabled": False,
     },
     "learner-dashboard": {
         "npm_package": "@openedx/frontend-app-learner-dashboard",
-        "npm_version": "^1.0.0-alpha || 0.0.0-dev",
+        "npm_version": "^1.0.0 || 0.0.0-dev",
         "enabled": False,
     },
     "instructor-dashboard": {
         "npm_package": "@openedx/frontend-app-instructor-dashboard",
-        "npm_version": "^1.0.0-alpha || 0.0.0-dev",
+        "npm_version": "^1.0.0 || 0.0.0-dev",
         "enabled": True,
     },
     "notifications": {
         "npm_package": "@openedx/frontend-app-notifications",
-        "npm_version": "^3.0.0-alpha || 0.0.0-dev",
+        "npm_version": "^3.0.0 || 0.0.0-dev",
         "enabled": True,
     },
 }

--- a/tutormfe/templates/mfe/build/mfe/site/package-lock.json
+++ b/tutormfe/templates/mfe/build/mfe/site/package-lock.json
@@ -9,11 +9,11 @@
       ],
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@^1.3.0 || 0.0.0-dev",
-        "@openedx/frontend-app-authn": "^1.0.0-alpha || 0.0.0-dev",
-        "@openedx/frontend-app-instructor-dashboard": "^1.0.0-alpha || 0.0.0-dev",
-        "@openedx/frontend-app-learner-dashboard": "^1.0.0-alpha || 0.0.0-dev",
-        "@openedx/frontend-app-notifications": "^3.0.0-alpha || 0.0.0-dev",
-        "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev"
+        "@openedx/frontend-app-authn": "^1.0.0 || 0.0.0-dev",
+        "@openedx/frontend-app-instructor-dashboard": "^1.0.0 || 0.0.0-dev",
+        "@openedx/frontend-app-learner-dashboard": "^1.0.0 || 0.0.0-dev",
+        "@openedx/frontend-app-notifications": "^3.0.0 || 0.0.0-dev",
+        "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev"
       },
       "devDependencies": {
         "@edx/browserslist-config": "latest",
@@ -4440,9 +4440,9 @@
       }
     },
     "node_modules/@openedx/frontend-app-authn": {
-      "version": "1.0.0-alpha.13",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-authn/-/frontend-app-authn-1.0.0-alpha.13.tgz",
-      "integrity": "sha512-hEn8YJ5Mee9ZBS0hgd7JErpZ1PgWrQg3erPgjoak4r5Eq7u036BpP/TCvUwBAM2thFyEMtYt6OlPsgfAXkjzQw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-authn/-/frontend-app-authn-1.0.0.tgz",
+      "integrity": "sha512-ZHP0KZQG7sStNMpBC1Qp90WkKk/HKVbQQmeE1yxHgR0isCj9DOLaHXyx6JecXEL1lrIsrwQj3Zmt1oWeXs+N0g==",
       "license": "AGPL-3.0",
       "workspaces": [
         "packages/*"
@@ -4468,7 +4468,7 @@
         "node": "^24.12"
       },
       "peerDependencies": {
-        "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev",
+        "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
         "@openedx/paragon": "^23",
         "@tanstack/react-query": "^5",
         "react": "^18",
@@ -4478,9 +4478,9 @@
       }
     },
     "node_modules/@openedx/frontend-app-instructor-dashboard": {
-      "version": "1.0.0-alpha.47",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-instructor-dashboard/-/frontend-app-instructor-dashboard-1.0.0-alpha.47.tgz",
-      "integrity": "sha512-YvgDfxGdf8hUpgToxs2lO4bwbJ12DJxhAsVjEzPkWT2zDsUw6EaTRQLNXEEn704QzeOpRCLPe+oh3ubjQ7CSkQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-instructor-dashboard/-/frontend-app-instructor-dashboard-1.0.0.tgz",
+      "integrity": "sha512-zD2HzsZUPSgqPYeKdbePglre+SEAKSe2e8pl0lLsKkwuui9YM+aNsmhu8GaN8MTs8GQ7aZk+2E+pcbCrAa0Gdg==",
       "license": "AGPL-3.0",
       "workspaces": [
         "packages/*"
@@ -4492,7 +4492,7 @@
         "react-helmet": "^6.1.0"
       },
       "peerDependencies": {
-        "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev",
+        "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
         "@openedx/paragon": "^23",
         "@tanstack/react-query": "^5",
         "react": "^18",
@@ -4502,9 +4502,9 @@
       }
     },
     "node_modules/@openedx/frontend-app-learner-dashboard": {
-      "version": "1.0.0-alpha.16",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-learner-dashboard/-/frontend-app-learner-dashboard-1.0.0-alpha.16.tgz",
-      "integrity": "sha512-mTpwz2GouA/5KZWsRs54ohwqzno1aNtsyUSGF+5CXDU5XhS8ZF2ZUr6j530iumtT67yR03wFcGMoy4SMyemC/Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-learner-dashboard/-/frontend-app-learner-dashboard-1.0.0.tgz",
+      "integrity": "sha512-maQRGegTlOXgftYWS28HA2iWT+2uMzo+g3VqKy3h/98w0EDY304wFuskCtcuaR2p8KgKl9NetKZ9ytsojGD3lA==",
       "license": "AGPL-3.0",
       "workspaces": [
         "packages/*"
@@ -4524,7 +4524,7 @@
         "react-share": "^5.2.2"
       },
       "peerDependencies": {
-        "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev",
+        "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
         "@openedx/paragon": "^23",
         "@tanstack/react-query": "^5",
         "@types/react": "^18",
@@ -4585,9 +4585,9 @@
       }
     },
     "node_modules/@openedx/frontend-app-notifications": {
-      "version": "3.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-notifications/-/frontend-app-notifications-3.0.0-alpha.3.tgz",
-      "integrity": "sha512-1hDyiTT3anZP52yaPs6Sng4Q5rzo5xZcwdhJxRhoRbBwDHgpnSNlOAks5wafm0S5qlcgDsHVYiD/NEnbJqwkig==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-notifications/-/frontend-app-notifications-3.0.0.tgz",
+      "integrity": "sha512-BqvCkKCWuE+kztfScmKX5ovg2zT8MzFJke6c/JNXx4XzcHBz15bNVpMzAuZ4qBycyefX0d/a2HkggcuVxWMGBw==",
       "license": "AGPL-3.0",
       "workspaces": [
         "packages/*"
@@ -4605,7 +4605,7 @@
         "uuid": "^13.0.0"
       },
       "peerDependencies": {
-        "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev",
+        "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
         "@openedx/paragon": "^23",
         "@tanstack/react-query": "^5",
         "react": "^18",
@@ -4628,9 +4628,9 @@
       }
     },
     "node_modules/@openedx/frontend-base": {
-      "version": "1.0.0-alpha.49",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.49.tgz",
-      "integrity": "sha512-5iEON9MUfifvxy8Zfo6kH7aKa+Bagg7TXhb5e0iO2lDPTK1q1xgL4VB/X/GLGFzSqF38I2FcSZh8vKB9x5Q6gg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.1.tgz",
+      "integrity": "sha512-Xi5D2SqXxTgbGzZRM3F0oSCJkR+6KWnGULAmfw3TQOkmJ43jDIZ0BZ1XrJySScaSXkibG4OZCtcHSjV4IHgm/g==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@babel/core": "^7.24.9",

--- a/tutormfe/templates/mfe/build/mfe/site/package.json
+++ b/tutormfe/templates/mfe/build/mfe/site/package.json
@@ -34,16 +34,16 @@
     "{{ app['npm_package'] }}": "{{ app['npm_version'] }}",
 {%- endfor %}
 {%- if get_frontend_compat_mfes() %}
-    "@openedx/frontend-base-compat": "^1.0.0-alpha || 0.0.0-dev",
-    "@edx/frontend-platform": "npm:@openedx/frontend-base-compat@^1.0.0-alpha || 0.0.0-dev",
-    "@openedx/frontend-plugin-framework": "npm:@openedx/frontend-base-compat@^1.0.0-alpha || 0.0.0-dev",
+    "@openedx/frontend-base-compat": "^1.0.0 || 0.0.0-dev",
+    "@edx/frontend-platform": "npm:@openedx/frontend-base-compat@^1.0.0 || 0.0.0-dev",
+    "@openedx/frontend-plugin-framework": "npm:@openedx/frontend-base-compat@^1.0.0 || 0.0.0-dev",
 {%- endif %}
-    "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev"
+    "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev"
   },
 {%- if get_frontend_compat_mfes() %}
   "overrides": {
-    "@edx/frontend-platform": "npm:@openedx/frontend-base-compat@^1.0.0-alpha || 0.0.0-dev",
-    "@openedx/frontend-plugin-framework": "npm:@openedx/frontend-base-compat@^1.0.0-alpha || 0.0.0-dev"
+    "@edx/frontend-platform": "npm:@openedx/frontend-base-compat@^1.0.0 || 0.0.0-dev",
+    "@openedx/frontend-plugin-framework": "npm:@openedx/frontend-base-compat@^1.0.0 || 0.0.0-dev"
   },
 {%- endif %}
   "devDependencies": {


### PR DESCRIPTION
### Description

Graduate frontend-base, frontend-base-compat, and the core frontend apps (authn, learner-dashboard, instructor-dashboard, notifications) from their alpha versions to the stable 1.0.0/3.0.0 releases now published on NPM ahead of Verawood.

This mirrors openedx/frontend-template-site#21 and closes out the tutor-mfe item of openedx/frontend-base#244.

### LLM usage notice

Built with assistance from Claude.