### PR TITLE
fix: give each MFE its own webpack build cache

### DIFF
--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -78,7 +78,10 @@ CMD ["/bin/bash", "-c", "npm run start --- --config ./webpack.dev-tutor.config.j
 ######## {{ app_name }} (production)
 FROM {{ app_name }}-common AS {{ app_name }}-prod
 ENV NODE_ENV=production
-RUN --mount=type=cache,target=/openedx/app/.cache,sharing=shared npm run build -- --config ./webpack.prod-tutor.config.js
+{#- Every MFE needs its own cache mount id: the id defaults to the target path, so
+    a single mount would make all MFEs share one webpack cache namespace, which is
+    slower than not caching at all. #}
+RUN --mount=type=cache,target=/openedx/app/.cache,id={{ app_name }}-webpack,sharing=locked npm run build -- --config ./webpack.prod-tutor.config.js
 {{ patch("mfe-dockerfile-post-npm-build") }}
 {{ patch("mfe-dockerfile-post-npm-build-{}".format(app_name)) }}
 {% endfor %}

--- a/tutormfe/templates/mfe/build/mfe/webpack.prod-tutor.config.js
+++ b/tutormfe/templates/mfe/build/mfe/webpack.prod-tutor.config.js
@@ -8,10 +8,13 @@ const baseProdConfig = (
 );
 
 {% if not MFE_REMOVE_WEBPACK_BUILD_CACHE %}
-// This speeds up subsequent builds when Docker layer cache is reused.
+// This speeds up subsequent builds when the BuildKit cache mount is reused.
+// `name` scopes the cache per MFE: frontend-build sets no cache name, so every
+// MFE would otherwise write to the same "default-production" namespace.
 baseProdConfig.cache = {
   type: 'filesystem',
   cacheDirectory: path.resolve(__dirname, '.cache'),
+  name: `${process.env.APP_ID || 'app'}-production`,
 };
 {% endif %}
 


### PR DESCRIPTION
The webpack filesystem cache added for production builds was shared by every MFE. A BuildKit cache mount id defaults to the target path, and frontend-build sets no `cache.name`, so all 11 applications concurrently read and wrote a single "default-production" pack set (688 MB after a few builds).

The result was that the cache cost more than it saved: the first rebuild after a full image build was slower than having no cache at all.

Measured on authn, release/ulmo.3, 11 MFEs, Apple M1 Max:

    no cache (baseline)   40.9s
    shared cache          62.2s first rebuild / 15.3s steady state
    per-MFE cache         17.1s first rebuild /  5.5s steady state

Replicated on profile and across two independent sessions: 3.0x faster on the first rebuild, 3.5x at steady state.

Also switch the mount to sharing=locked. Webpack's filesystem cache is not safe for concurrent writers, and with per-MFE ids the only remaining contention is two builds of the same MFE, which should serialise rather than race.