### PR TITLE
ci: publish the indigo variant of the mfe image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,10 @@
 variables:
     TUTOR_PLUGIN: mfe
     TUTOR_IMAGES: mfe account-dev admin-console-dev authn-dev authoring-dev communications-dev discussions-dev gradebook-dev learner-dashboard-dev learning-dev ora-grading-dev profile-dev
+    # Just the "mfe" image: it is the only one above that tutor-indigo renames. The dev
+    # images are named after MFE_DOCKER_IMAGE_DEV_PREFIX, which indigo leaves alone, so
+    # listing them here would push indigo-themed content over their unthemed tags.
+    TUTOR_INDIGO_IMAGES: mfe
     TUTOR_PYPI_PACKAGE: tutor-mfe
     GITHUB_REPO: overhangio/tutor-mfe
 


### PR DESCRIPTION
Enabling tutor-indigo renames the MFE image, so a platform running indigo pulls `openedx-mfe:<version>-indigo`. That image was only ever pushed by tutor-indigo's own pipeline, which installs tutor-mfe from PyPI, so it existed only for whichever tutor-mfe version happened to be released at the time.

The v21 line shows the failure mode:

- `2026-08-04 09:38` tutor-indigo v21.2.1 pushes `openedx-mfe:21.0.0-indigo`, tutor-mfe on PyPI still being 21.0.0
- `2026-08-04 11:59` tutor-mfe v21.0.1 pushes `openedx-mfe:21.0.1`, with no indigo variant
- every indigo platform on v21 then resolves tutor-mfe to 21.0.1 and fails with `manifest for overhangio/openedx-mfe:21.0.1-indigo not found`

`$TUTOR_INDIGO_IMAGES` (added in community/tutor-ci) makes our own pipeline build and push the indigo variant alongside the plain one, the way tutor's pipeline has always done for the openedx image. Only `mfe` is listed: it is the sole image here that indigo renames, since the dev images are named from `MFE_DOCKER_IMAGE_DEV_PREFIX`, which indigo leaves alone.

Note this is inert until tutor-indigo has a release on the same major line. On v22 the pass logs `No tutor-indigo release for v22: skipping indigo images` and succeeds; it starts publishing once tutor-indigo 22.x exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)