### PR TITLE
docs: fix FRONTEND_SLOTS slot operation example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -914,30 +914,38 @@ Using Frontend Slots
 
 The ``FRONTEND_SLOTS`` filter is the frontend-base equivalent of ``PLUGIN_SLOTS``. Instead of targeting individual MFEs by name, it registers slot operations globally in the site's ``customApp``, where they apply to all frontend apps served by the site.
 
-Each item added to the filter is a string containing a TypeScript ``SlotOperation`` object literal. For example, to replace the default footer with a custom one:
+Each item added to the filter is a string containing a TypeScript ``SlotOperation`` object literal. Because these literals end up in ``customApp.tsx``, which is type-checked, the ``op`` field must be one of the ``WidgetOperationTypes`` or ``LayoutOperationTypes`` constants, imported via the ``mfe-site-custom-app-imports`` patch. For example, to replace the default footer with a custom one:
 
 .. code-block:: python
 
+    from tutor import hooks
     from tutormfe.hooks import FRONTEND_SLOTS
+
+    hooks.Filters.ENV_PATCHES.add_item(
+        (
+            "mfe-site-custom-app-imports",
+            """
+    import { WidgetOperationTypes } from '@openedx/frontend-base';
+    """,
+        )
+    )
 
     FRONTEND_SLOTS.add_items([
         """
         {
           slotId: 'org.openedx.frontend.slot.footer.main.v1',
-          op: 'widgetReplace',
+          op: WidgetOperationTypes.REPLACE,
           id: 'customFooter',
-          relatedId: 'defaultContent',
+          relatedId: 'org.openedx.frontend.widget.footer.main.v1',
           element: (
             <h1>This is the footer.</h1>
           ),
         }""",
     ])
 
-Unlike ``PLUGIN_SLOTS``, there's no MFE name parameter - slot operations are applied site-wide. The ``slotId`` field identifies which slot to target, and each operation uses the ``SlotOperation`` format defined by `@openedx/frontend-base <https://github.com/openedx/frontend-base/>`_. Widget operations include ``widgetAppend``, ``widgetPrepend``, ``widgetInsertBefore``, ``widgetInsertAfter``, ``widgetReplace``, ``widgetRemove``, and ``widgetOptions``. Layout operations include ``layoutReplace`` and ``layoutOptions``.
+Unlike ``PLUGIN_SLOTS``, there's no MFE name parameter - slot operations are applied site-wide. The ``slotId`` field identifies which slot to target, and each operation uses the ``SlotOperation`` format defined by `@openedx/frontend-base <https://github.com/openedx/frontend-base/>`_. Widget operations are ``WidgetOperationTypes.APPEND``, ``PREPEND``, ``INSERT_BEFORE``, ``INSERT_AFTER``, ``REPLACE``, ``REMOVE``, and ``OPTIONS``. Layout operations are ``LayoutOperationTypes.REPLACE`` and ``OPTIONS``.
 
 You can also use the ``mfe-site-custom-app-final`` and ``mfe-site-custom-app-imports`` patches to add arbitrary code directly to ``customApp.tsx``, bypassing the filter entirely.
-
-Note that the examples above use string literals like ``'widgetRemove'`` rather than the ``WidgetOperationTypes`` constants shown in the app package section below. Using the constants would require adding an import via ``mfe-site-custom-app-imports``, which isn't worth the trouble here - the string values are equivalent.
 
 ``FRONTEND_SLOTS`` is best suited for simple slot operations or as an easier migration path from ``PLUGIN_SLOTS``. For more complex frontend plugins, you should create an npm app package instead (see below).
 


### PR DESCRIPTION
### Description

The `FRONTEND_SLOTS` example in the README doesn't work as documented. Its `op` field used a plain string literal, but `op` is typed as a TypeScript enum in frontend-base, so `op: 'widgetReplace'` fails the type check when `customApp.tsx` is built. The example now imports `WidgetOperationTypes` through the `mfe-site-custom-app-imports` patch and uses `WidgetOperationTypes.REPLACE`. The paragraph claiming the string values were equivalent, and not worth an import, is gone.

The example's `relatedId: 'defaultContent'` was also wrong. In frontend-base, `defaultContent` is the id of the widget synthesized from a slot's JSX children, but the shell renders the footer slot without children and fills it by appending a widget with the id `org.openedx.frontend.widget.footer.main.v1`. A `relatedId` that matches nothing is silently ignored, so the documented operation had no effect at all. The example now targets that widget id.

Finally, the list of available operations names the enum constants instead of their underlying string values, so it matches what a plugin author actually has to write.

### LLM usage notice

Built with assistance from Claude.
