### PR TITLE
feat: stop setting the ENABLE_MFE_CONFIG_API toggle

### DIFF
--- a/changelog.d/20260826_000000_arbrandes_depr_enable_mfe_config_api.md
+++ b/changelog.d/20260826_000000_arbrandes_depr_enable_mfe_config_api.md
@@ -1,0 +1,1 @@
+- [Deprecation] Stop setting the `ENABLE_MFE_CONFIG_API` toggle, which no longer exists upstream. (by @arbrandes)

--- a/tutormfe/patches/openedx-lms-common-settings
+++ b/tutormfe/patches/openedx-lms-common-settings
@@ -1,7 +1,6 @@
-# MFE: enable API and set a low cache timeout for the settings. otherwise, weird
-# configuration bugs occur. Also, the view is not costly at all, and it's also cached on
-# the frontend. (5 minutes, hardcoded)
-ENABLE_MFE_CONFIG_API = True
+# MFE: set a low cache timeout for the settings API. otherwise, weird configuration
+# bugs occur. Also, the view is not costly at all, and it's also cached on the
+# frontend. (5 minutes, hardcoded)
 MFE_CONFIG_API_CACHE_TIMEOUT = 1
 
 # MFE-specific settings


### PR DESCRIPTION
### Description

Removes `ENABLE_MFE_CONFIG_API = True` from the LMS common settings patch. The toggle is deleted upstream in openedx/openedx-platform#39019, after which both `/api/mfe_config/v1` and `/api/frontend_site_config/v1/` respond unconditionally and setting the key does nothing.

This is a cleanup, not a lockstep requirement: upstream simply ignores the key once merged. But it must not merge before that PR does, since the toggle still defaults to `False` on master and dropping the line early would break MFE configuration. Hence the draft status.

`MFE_CONFIG_API_CACHE_TIMEOUT` is untouched and still applies.

### LLM usage notice

Built with assistance from Claude.
