### PR TITLE
feat: upgrade to frontend-base 2.0, add the Catalog app

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,9 +134,9 @@ Catalog
 ~~~~~~~~
 
 .. image:: https://raw.githubusercontent.com/overhangio/tutor-mfe/release/media/catalog.png
-    :alt: Catalog MFE screenshot
+    :alt: Catalog screenshot
 
-The Catalog MFE replaces the former Home, Course About and Course catalog pages, which is the main part of the LMS where students start interacting with courses.
+The Catalog replaces the former Home, Course About and Course catalog pages, which is the main part of the LMS where students start interacting with courses. It is available at ``http(s)://{{ MFE_HOST }}/catalog``.
 
 Instructor Dashboard
 ~~~~~~~~~~~~~~~~~~~~
@@ -747,26 +747,27 @@ When frontend apps are enabled, the plugin builds a frontend-base site that bund
 Frontend apps
 ~~~~~~~~~~~~~
 
-Frontend apps are npm packages that plug into the frontend-base site. This plugin ships with four core frontend apps:
+Frontend apps are npm packages that plug into the frontend-base site. This plugin ships with five core frontend apps, all enabled by default:
 
-- ``authn`` (``@openedx/frontend-app-authn``): disabled by default
-- ``learner-dashboard`` (``@openedx/frontend-app-learner-dashboard``): disabled by default
-- ``instructor-dashboard`` (``@openedx/frontend-app-instructor-dashboard``): enabled by default
-- ``notifications`` (``@openedx/frontend-app-notifications``): enabled by default
+- ``catalog`` (``@openedx/frontend-app-catalog``)
+- ``authn`` (``@openedx/frontend-app-authn``)
+- ``learner-dashboard`` (``@openedx/frontend-app-learner-dashboard``)
+- ``instructor-dashboard`` (``@openedx/frontend-app-instructor-dashboard``)
+- ``notifications`` (``@openedx/frontend-app-notifications``)
 
-To enable apps, use the ``tutormfe.hooks.FRONTEND_APPS`` filter:
+To disable apps, use the ``tutormfe.hooks.FRONTEND_APPS`` filter:
 
 .. code-block:: python
 
     from tutormfe.hooks import FRONTEND_APPS
 
     @FRONTEND_APPS.add()
-    def _enable_core_apps(apps):
-        apps["authn"]["enabled"] = True
-        apps["learner-dashboard"]["enabled"] = True
+    def _disable_core_apps(apps):
+        apps["authn"]["enabled"] = False
+        apps["learner-dashboard"]["enabled"] = False
         return apps
 
-Note that if an enabled frontend app matches a legacy MFE, the legacy MFE will be effectively disabled.  This is the case with both Authn and Learner Dashboard if the example above is followed.
+Note that if an enabled frontend app matches a legacy MFE, the legacy MFE will be effectively disabled.  This is the case for every core frontend app, unless it is disabled as in the example above.
 
 Enabling or disabling existing apps does not require rebuilding tutor-mfe images: after a `tutor config save`, only a Tutor restart is required.
 
@@ -816,7 +817,7 @@ Runtime configuration
 
 By default, the frontend-base site fetches its runtime configuration from the LMS at ``/api/frontend_site_config/v1/``. This configuration is populated from the ``FRONTEND_SITE_CONFIG`` dictionary in the LMS settings.
 
-Tutor-mfe automatically populates ``FRONTEND_SITE_CONFIG`` with base URLs, login/logout URLs, external routes, and per-app configuration. To add custom values or override existing ones, use the ``mfe-lms-common-settings``, ``mfe-lms-production-settings``, or ``mfe-lms-development-settings`` patches:
+Tutor-mfe automatically populates ``FRONTEND_SITE_CONFIG`` with base URLs, login/logout URLs, external routes, and common app configuration. To add custom values or override existing ones, use the ``mfe-lms-common-settings``, ``mfe-lms-production-settings``, or ``mfe-lms-development-settings`` patches:
 
 .. code-block:: python
 

--- a/changelog.d/20260829_000000_arbrandes_frontend_base_2_0.md
+++ b/changelog.d/20260829_000000_arbrandes_frontend_base_2_0.md
@@ -1,0 +1,4 @@
+- 💥[Feature] Ship the Catalog as a frontend app (`@openedx/frontend-app-catalog`), enabled by default. (by @arbrandes)
+- 💥[Feature] Enable the Authn and Learner Dashboard frontend apps by default. (by @arbrandes)
+- 💥[Feature] Build the frontend-base site against `@openedx/frontend-base` 2.0. (by @arbrandes)
+- [Bugfix] Set `ENABLE_CATALOG_MICROFRONTEND` in the CMS as well, so that Studio's course "about" links point at the catalog instead of the LMS. (by @arbrandes)

--- a/changelog.d/20260829_010000_arbrandes_superseded_mfe_dev_ports.md
+++ b/changelog.d/20260829_010000_arbrandes_superseded_mfe_dev_ports.md
@@ -1,0 +1,1 @@
+- [Bugfix] Stop legacy MFEs superseded by an enabled frontend app from binding their development ports, which also kept a mounted repo from being served twice. (by @arbrandes)

--- a/changelog.d/20260829_020000_arbrandes_authn_mfe_toggle.md
+++ b/changelog.d/20260829_020000_arbrandes_authn_mfe_toggle.md
@@ -1,0 +1,1 @@
+- [Bugfix] Set `ENABLE_AUTHN_MICROFRONTEND` as a top-level Django setting instead of a `FEATURES` key, so the LMS once again redirects `/login` and `/register` to the Authn MFE. (by @arbrandes)

--- a/tutormfe/patches/openedx-cms-common-settings
+++ b/tutormfe/patches/openedx-cms-common-settings
@@ -1,0 +1,4 @@
+# MFE-specific settings
+{% if get_mfe("catalog") or is_frontend_app_enabled("catalog") %}
+ENABLE_CATALOG_MICROFRONTEND = True
+{% endif %}

--- a/tutormfe/patches/openedx-cms-development-settings
+++ b/tutormfe/patches/openedx-cms-development-settings
@@ -6,7 +6,9 @@ LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}:{{ get_mfe('authoring')["port"] 
 CSRF_TRUSTED_ORIGINS.append("http://{{ MFE_HOST }}:{{ get_mfe('authoring')["port"] }}")
 {% endif %}
 
-{% if get_mfe("catalog") %}
+{% if is_frontend_app_enabled("catalog") %}
+CATALOG_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ MFE_SITE_PORT }}/catalog"
+{% elif get_mfe("catalog") %}
 CATALOG_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ get_mfe("catalog")["port"] }}/catalog"
 {% endif %}
 

--- a/tutormfe/patches/openedx-cms-production-settings
+++ b/tutormfe/patches/openedx-cms-production-settings
@@ -3,7 +3,7 @@
 COURSE_AUTHORING_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/authoring"
 {% endif %}
 
-{% if get_mfe("catalog") %}
+{% if get_mfe("catalog") or is_frontend_app_enabled("catalog") %}
 CATALOG_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/catalog"
 {% endif %}
 

--- a/tutormfe/patches/openedx-lms-common-settings
+++ b/tutormfe/patches/openedx-lms-common-settings
@@ -7,7 +7,7 @@ MFE_CONFIG_API_CACHE_TIMEOUT = 1
 {% if get_mfe("authn") or is_frontend_app_enabled("authn") %}
 FEATURES['ENABLE_AUTHN_MICROFRONTEND'] = True
 {% endif %}
-{% if get_mfe("catalog") %}
+{% if get_mfe("catalog") or is_frontend_app_enabled("catalog") %}
 ENABLE_CATALOG_MICROFRONTEND = True
 {% endif %}
 {% if get_mfe("communications") %}

--- a/tutormfe/patches/openedx-lms-common-settings
+++ b/tutormfe/patches/openedx-lms-common-settings
@@ -5,7 +5,7 @@ MFE_CONFIG_API_CACHE_TIMEOUT = 1
 
 # MFE-specific settings
 {% if get_mfe("authn") or is_frontend_app_enabled("authn") %}
-FEATURES['ENABLE_AUTHN_MICROFRONTEND'] = True
+ENABLE_AUTHN_MICROFRONTEND = True
 {% endif %}
 {% if get_mfe("catalog") or is_frontend_app_enabled("catalog") %}
 ENABLE_CATALOG_MICROFRONTEND = True

--- a/tutormfe/patches/openedx-lms-development-settings
+++ b/tutormfe/patches/openedx-lms-development-settings
@@ -32,7 +32,9 @@ FRONTEND_SITE_CONFIG = {
     "externalRoutes": [
         {"role": "org.openedx.frontend.role.logout", "url": "http://{{ LMS_HOST }}:8000/logout"},
     ],
-    "commonAppConfig": {},
+    "commonAppConfig": {
+        "INFO_EMAIL": "{{ CONTACT_EMAIL }}",
+    },
 }
 
 # MFE-specific settings
@@ -87,6 +89,7 @@ INSTRUCTOR_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ MFE_SITE_PORT }}/instru
 {% if get_mfe("learning") %}
 LEARNING_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ get_mfe("learning")["port"] }}/learning"
 MFE_CONFIG["LEARNING_BASE_URL"] = "http://{{ MFE_HOST }}:{{ get_mfe("learning")["port"] }}/learning"
+FRONTEND_SITE_CONFIG["commonAppConfig"]["LEARNING_BASE_URL"] = "http://{{ MFE_HOST }}:{{ get_mfe("learning")["port"] }}/learning"
 {% endif %}
 
 {% if get_mfe("ora-grading") %}
@@ -109,7 +112,9 @@ ADMIN_CONSOLE_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ get_mfe("admin-conso
 MFE_CONFIG["ADMIN_CONSOLE_URL"] = ADMIN_CONSOLE_MICROFRONTEND_URL
 {% endif %}
 
-{% if get_mfe("catalog") %}
+{% if is_frontend_app_enabled("catalog") %}
+CATALOG_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ MFE_SITE_PORT }}/catalog"
+{% elif get_mfe("catalog") %}
 CATALOG_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ get_mfe("catalog")["port"] }}/catalog"
 {% endif %}
 

--- a/tutormfe/patches/openedx-lms-production-settings
+++ b/tutormfe/patches/openedx-lms-production-settings
@@ -32,7 +32,9 @@ FRONTEND_SITE_CONFIG = {
     "externalRoutes": [
         {"role": "org.openedx.frontend.role.logout", "url": "{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}/logout"},
     ],
-    "commonAppConfig": {},
+    "commonAppConfig": {
+        "INFO_EMAIL": "{{ CONTACT_EMAIL }}",
+    },
 }
 
 # MFE-specific settings
@@ -82,6 +84,7 @@ INSTRUCTOR_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{%
 {% if get_mfe("learning") %}
 LEARNING_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/learning"
 MFE_CONFIG["LEARNING_BASE_URL"] = "{{ "https" if ENABLE_HTTPS else "http" }}://{{ MFE_HOST }}/learning"
+FRONTEND_SITE_CONFIG["commonAppConfig"]["LEARNING_BASE_URL"] = "{{ "https" if ENABLE_HTTPS else "http" }}://{{ MFE_HOST }}/learning"
 {% endif %}
 
 {% if get_mfe("ora-grading") %}
@@ -104,7 +107,7 @@ ADMIN_CONSOLE_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http:/
 MFE_CONFIG["ADMIN_CONSOLE_URL"] = ADMIN_CONSOLE_MICROFRONTEND_URL
 {% endif %}
 
-{% if get_mfe("catalog") %}
+{% if get_mfe("catalog") or is_frontend_app_enabled("catalog") %}
 CATALOG_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/catalog"
 {% endif %}
 

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -194,6 +194,8 @@ class MFEMountData:
     def _categorize_mfes(self, mounts: list[str]) -> None:
         """Populates mounted and unmounted MFE lists based on mount data."""
         for app_name, app in iter_mfes():
+            if is_frontend_app_enabled(app_name):
+                continue
             mfe_mounts = list(iter_mounts(mounts, app_name))
             if mfe_mounts:
                 self.mounted.append((app_name, app, mfe_mounts))

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -122,22 +122,27 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
 CORE_FRONTEND_APPS: dict[str, FRONTEND_APP_ATTRS_TYPE] = {
     "authn": {
         "npm_package": "@openedx/frontend-app-authn",
-        "npm_version": "^1.0.0 || 0.0.0-dev",
-        "enabled": False,
+        "npm_version": "^2.0.0-alpha || 0.0.0-dev",
+        "enabled": True,
     },
     "learner-dashboard": {
         "npm_package": "@openedx/frontend-app-learner-dashboard",
-        "npm_version": "^1.0.0 || 0.0.0-dev",
-        "enabled": False,
+        "npm_version": "^2.0.0-alpha || 0.0.0-dev",
+        "enabled": True,
     },
     "instructor-dashboard": {
         "npm_package": "@openedx/frontend-app-instructor-dashboard",
-        "npm_version": "^1.0.0 || 0.0.0-dev",
+        "npm_version": "^2.0.0-alpha || 0.0.0-dev",
         "enabled": True,
     },
     "notifications": {
         "npm_package": "@openedx/frontend-app-notifications",
-        "npm_version": "^3.0.0 || 0.0.0-dev",
+        "npm_version": "^4.0.0-alpha || 0.0.0-dev",
+        "enabled": True,
+    },
+    "catalog": {
+        "npm_package": "@openedx/frontend-app-catalog",
+        "npm_version": "^1.0.0-alpha || 0.0.0-dev",
         "enabled": True,
     },
 }

--- a/tutormfe/templates/mfe/build/mfe/site/package-lock.json
+++ b/tutormfe/templates/mfe/build/mfe/site/package-lock.json
@@ -9,11 +9,12 @@
       ],
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@^1.3.0 || 0.0.0-dev",
-        "@openedx/frontend-app-authn": "^1.0.0 || 0.0.0-dev",
-        "@openedx/frontend-app-instructor-dashboard": "^1.0.0 || 0.0.0-dev",
-        "@openedx/frontend-app-learner-dashboard": "^1.0.0 || 0.0.0-dev",
-        "@openedx/frontend-app-notifications": "^3.0.0 || 0.0.0-dev",
-        "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev"
+        "@openedx/frontend-app-authn": "^2.0.0-alpha || 0.0.0-dev",
+        "@openedx/frontend-app-catalog": "^1.0.0-alpha || 0.0.0-dev",
+        "@openedx/frontend-app-instructor-dashboard": "^2.0.0-alpha || 0.0.0-dev",
+        "@openedx/frontend-app-learner-dashboard": "^2.0.0-alpha || 0.0.0-dev",
+        "@openedx/frontend-app-notifications": "^4.0.0-alpha || 0.0.0-dev",
+        "@openedx/frontend-base": "^2.0.0-alpha || 0.0.0-dev"
       },
       "devDependencies": {
         "@edx/browserslist-config": "latest",
@@ -2583,106 +2584,14 @@
       }
     },
     "node_modules/@formatjs/intl": {
-      "version": "2.10.15",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.10.15.tgz",
-      "integrity": "sha512-i6+xVqT+6KCz7nBfk4ybMXmbKO36tKvbMKtgFz9KV+8idYFyFbfwKooYk8kGjyA5+T5f1kEPQM5IDLXucTAQ9g==",
+      "version": "4.1.19",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-4.1.19.tgz",
+      "integrity": "sha512-bZMROATl+rzfL8wsDZ53i8XWHx5e6rVr8QlGT5GDvHImEUro4WE9pxUd2dobzmI3CtD+zkt/wkEdqcb+3CK8Fg==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/icu-messageformat-parser": "2.9.4",
-        "@formatjs/intl-displaynames": "6.8.5",
-        "@formatjs/intl-listformat": "7.7.5",
-        "intl-messageformat": "10.7.7",
-        "tslib": "2"
-      },
-      "peerDependencies": {
-        "typescript": "^4.7 || 5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@formatjs/intl-displaynames": {
-      "version": "6.8.5",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.8.5.tgz",
-      "integrity": "sha512-85b+GdAKCsleS6cqVxf/Aw/uBd+20EM0wDpgaxzHo3RIR3bxF4xCJqH/Grbzx8CXurTgDDZHPdPdwJC+May41w==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-displaynames/node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
-      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-displaynames/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz",
-      "integrity": "sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-displaynames/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
-      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-listformat": {
-      "version": "7.7.5",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.7.5.tgz",
-      "integrity": "sha512-Wzes10SMNeYgnxYiKsda4rnHP3Q3II4XT2tZyOgnH5fWuHDtIkceuWlRQNsvrI3uiwP4hLqp2XdQTCsfkhXulg==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-listformat/node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
-      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-listformat/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz",
-      "integrity": "sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-listformat/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
-      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2"
+        "@formatjs/fast-memoize": "3.1.7",
+        "@formatjs/icu-messageformat-parser": "3.5.17",
+        "intl-messageformat": "11.2.14"
       }
     },
     "node_modules/@formatjs/intl-localematcher": {
@@ -2694,55 +2603,26 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/@formatjs/intl/node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
-      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
     "node_modules/@formatjs/intl/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz",
-      "integrity": "sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2"
-      }
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.7.tgz",
+      "integrity": "sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==",
+      "license": "MIT"
     },
     "node_modules/@formatjs/intl/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.4.tgz",
-      "integrity": "sha512-Tbvp5a9IWuxUcpWNIW6GlMQYEc4rwNHR259uUFoKWNN1jM9obf9Ul0e+7r7MvFOBNcN+13K7NuKCKqQiAn1QEg==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.17.tgz",
+      "integrity": "sha512-cN9jhVqT7u0K9tix43fhjoUwL0nazyW6zsNIXs2QdPADr+nurPfYyssUiMqcSCGlPcCiqnYVxgSn7zBSuI+5Bg==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/icu-skeleton-parser": "1.8.8",
-        "tslib": "2"
+        "@formatjs/icu-skeleton-parser": "2.1.11"
       }
     },
     "node_modules/@formatjs/intl/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.8.tgz",
-      "integrity": "sha512-vHwK3piXwamFcx5YQdCdJxUQ1WdTl6ANclt5xba5zLGDv5Bsur7qz8AD7BevaKxITwpgDeU0u8My3AIibW9ywA==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
-      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2"
-      }
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.11.tgz",
+      "integrity": "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==",
+      "license": "MIT"
     },
     "node_modules/@formatjs/ts-transformer": {
       "version": "3.14.2",
@@ -4440,9 +4320,9 @@
       }
     },
     "node_modules/@openedx/frontend-app-authn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-authn/-/frontend-app-authn-1.0.0.tgz",
-      "integrity": "sha512-ZHP0KZQG7sStNMpBC1Qp90WkKk/HKVbQQmeE1yxHgR0isCj9DOLaHXyx6JecXEL1lrIsrwQj3Zmt1oWeXs+N0g==",
+      "version": "2.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-authn/-/frontend-app-authn-2.0.0-alpha.2.tgz",
+      "integrity": "sha512-xpUqG3bSYTW2zz4UT08wg7W7hweDyHZ7UgROZJb2WLxjhpPA7hhAzxjb3QfO/hhHo7ZXcKHBEoEf8NKvQCjCAw==",
       "license": "AGPL-3.0",
       "workspaces": [
         "packages/*"
@@ -4468,7 +4348,30 @@
         "node": "^24.12"
       },
       "peerDependencies": {
-        "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
+        "@openedx/frontend-base": "^2.0.0-alpha.4 || 0.0.0-dev",
+        "@openedx/paragon": "^23",
+        "@tanstack/react-query": "^5",
+        "react": "^18",
+        "react-dom": "^18",
+        "react-router": "^6",
+        "react-router-dom": "^6"
+      }
+    },
+    "node_modules/@openedx/frontend-app-catalog": {
+      "version": "1.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-catalog/-/frontend-app-catalog-1.0.0-alpha.2.tgz",
+      "integrity": "sha512-QCqXLldNBcj+TPdF7LXxqKVl2+m2ve1iShRAYw+mLyg2eJ7v06J7lY3+BS1RGBGfJ7cfDzLt5K4UDJV9FblFsA==",
+      "license": "AGPL-3.0",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@edx/openedx-atlas": "^0.7.0",
+        "lodash.capitalize": "^4.2.1",
+        "react-helmet": "^6.1.0"
+      },
+      "peerDependencies": {
+        "@openedx/frontend-base": "^2.0.0-alpha.4 || 0.0.0-dev",
         "@openedx/paragon": "^23",
         "@tanstack/react-query": "^5",
         "react": "^18",
@@ -4478,9 +4381,9 @@
       }
     },
     "node_modules/@openedx/frontend-app-instructor-dashboard": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-instructor-dashboard/-/frontend-app-instructor-dashboard-1.3.0.tgz",
-      "integrity": "sha512-RNP6m0mRkGqOnH2XDrJQshoLFQKrFYMgWBbSEeq0eh3NDZfjTskphr6gZxVQuWjyv84CPSq/7hiczOomzzvb1A==",
+      "version": "2.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-instructor-dashboard/-/frontend-app-instructor-dashboard-2.0.0-alpha.1.tgz",
+      "integrity": "sha512-kgYFZzsy7A7NSBYG74T+Owr8g9iLGpviwgrdiD3+BPgWpJ0XcJjWLqW4dgb6sQ+FIUa4yuR23a3cT+ka8/sMmA==",
       "license": "AGPL-3.0",
       "workspaces": [
         "packages/*"
@@ -4492,7 +4395,7 @@
         "react-helmet": "^6.1.0"
       },
       "peerDependencies": {
-        "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
+        "@openedx/frontend-base": "^2.0.0-alpha.5 || 0.0.0-dev",
         "@openedx/paragon": "^23",
         "@tanstack/react-query": "^5",
         "react": "^18",
@@ -4502,9 +4405,9 @@
       }
     },
     "node_modules/@openedx/frontend-app-learner-dashboard": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-learner-dashboard/-/frontend-app-learner-dashboard-1.0.0.tgz",
-      "integrity": "sha512-maQRGegTlOXgftYWS28HA2iWT+2uMzo+g3VqKy3h/98w0EDY304wFuskCtcuaR2p8KgKl9NetKZ9ytsojGD3lA==",
+      "version": "2.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-learner-dashboard/-/frontend-app-learner-dashboard-2.0.0-alpha.2.tgz",
+      "integrity": "sha512-RPHp6f0dyq/PTttnBJXTJn3dhh+kg66f9svCofTR5cG81jqISDNaqE9Qn9j6hA+1f/v0x2GkYLgO/DRB5Dtyfw==",
       "license": "AGPL-3.0",
       "workspaces": [
         "packages/*"
@@ -4524,7 +4427,7 @@
         "react-share": "^5.2.2"
       },
       "peerDependencies": {
-        "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
+        "@openedx/frontend-base": "^2.0.0-alpha.4 || 0.0.0-dev",
         "@openedx/paragon": "^23",
         "@tanstack/react-query": "^5",
         "@types/react": "^18",
@@ -4585,9 +4488,9 @@
       }
     },
     "node_modules/@openedx/frontend-app-notifications": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-notifications/-/frontend-app-notifications-3.0.0.tgz",
-      "integrity": "sha512-BqvCkKCWuE+kztfScmKX5ovg2zT8MzFJke6c/JNXx4XzcHBz15bNVpMzAuZ4qBycyefX0d/a2HkggcuVxWMGBw==",
+      "version": "4.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-notifications/-/frontend-app-notifications-4.0.0-alpha.1.tgz",
+      "integrity": "sha512-+yNJlcXyn/CCfJm8RRO5dtg+s/cNgfmkAYZL6BLVJTYEPkhmdxaVclt0D4RrI+BysquB4PqCSgZz1SUB/enhqg==",
       "license": "AGPL-3.0",
       "workspaces": [
         "packages/*"
@@ -4605,7 +4508,7 @@
         "uuid": "^13.0.0"
       },
       "peerDependencies": {
-        "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
+        "@openedx/frontend-base": "^2.0.0-alpha.4 || 0.0.0-dev",
         "@openedx/paragon": "^23",
         "@tanstack/react-query": "^5",
         "react": "^18",
@@ -4628,9 +4531,9 @@
       }
     },
     "node_modules/@openedx/frontend-base": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.1.tgz",
-      "integrity": "sha512-Xi5D2SqXxTgbGzZRM3F0oSCJkR+6KWnGULAmfw3TQOkmJ43jDIZ0BZ1XrJySScaSXkibG4OZCtcHSjV4IHgm/g==",
+      "version": "2.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-2.0.0-alpha.9.tgz",
+      "integrity": "sha512-v5fa4mC6AwMiMvYKgwVannmejPMFJq2427rr4z6l8ngUc7/eKJXXGt2jP8W2/Ue9JCk4PMaWBqjG+m8I7FB4pg==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@babel/core": "^7.24.9",
@@ -4690,7 +4593,7 @@
         "prop-types": "^15.8.1",
         "react-dev-utils": "12.0.1",
         "react-focus-on": "^3.10.2",
-        "react-intl": "^6.6.6",
+        "react-intl": "^10.1.20",
         "react-refresh": "0.18.0",
         "react-refresh-typescript": "^2.0.9",
         "react-responsive": "^10.0.0",
@@ -4719,7 +4622,7 @@
         "openedx": "dist/tools/cli/openedx.js"
       },
       "peerDependencies": {
-        "@openedx/paragon": "^23.20.0",
+        "@openedx/paragon": "^23.23.0",
         "@tanstack/react-query": "^5.81.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -4761,9 +4664,9 @@
       "license": "MIT"
     },
     "node_modules/@openedx/paragon": {
-      "version": "23.21.1",
-      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-23.21.1.tgz",
-      "integrity": "sha512-jD7fIaILgqiiDXuUTg5hXgZxI8Ei5x2l2fzSElCTGY7qEYQwd/F3am9UFDp/60mp84L9AlyNW21Hlj0X4e8lYA==",
+      "version": "23.23.0",
+      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-23.23.0.tgz",
+      "integrity": "sha512-dr4zDytE7YC/Hk3sIl3MBgLyeIJBZpPp0tI2x+SQ1d/tJXhyJk4pDOfG8bFbGHt4jaM/cwjwX25jaTUV1jszIg==",
       "license": "Apache-2.0",
       "peer": true,
       "workspaces": [
@@ -4779,7 +4682,6 @@
         "axios": "^1.0.0",
         "bootstrap": "^4.6.2",
         "chalk": "^4.1.2",
-        "child_process": "^1.0.2",
         "chroma-js": "^3.0.0",
         "classnames": "^2.3.1",
         "cli-progress": "^3.12.0",
@@ -4825,7 +4727,7 @@
       "peerDependencies": {
         "react": "^16.8.6 || ^17 || ^18",
         "react-dom": "^16.8.6 || ^17 || ^18",
-        "react-intl": "^5.25.1 || ^6.4.0"
+        "react-intl": "^5.25.1 || ^6.4.0 || ^10.1.20"
       }
     },
     "node_modules/@openedx/paragon/node_modules/glob": {
@@ -5907,18 +5809,6 @@
         "@types/tinycolor2": "*"
       }
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
-      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
-      "license": "MIT",
-      "dependencies": {
-        "hoist-non-react-statics": "^3.3.0"
-      },
-      "peerDependencies": {
-        "@types/react": "*"
-      }
-    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -6025,7 +5915,8 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/qs": {
       "version": "6.15.0",
@@ -6044,6 +5935,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -7922,13 +7814,6 @@
       "engines": {
         "node": ">=22.0.0"
       }
-    },
-    "node_modules/child_process": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-      "integrity": "sha512-Wmza/JzL0SiWz7kl6MhIKT5ceIlnFPJX+lwUGj7Clhy5MMldsSoJR0+uvRzOS5Kv45Mq7t1PoE8TsOA9bzvb6g==",
-      "license": "ISC",
-      "peer": true
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -11274,21 +11159,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
     "node_modules/hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
@@ -11874,66 +11744,35 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "10.7.7",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.7.tgz",
-      "integrity": "sha512-F134jIoeYMro/3I0h08D0Yt4N9o9pjddU/4IIxMMURqbAtI2wu70X8hvG1V48W49zXHXv3RKSF/po+0fDfsGjA==",
+      "version": "11.2.14",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.14.tgz",
+      "integrity": "sha512-9f2VD1HFuxUvMw0RxsaP8WmMns6JRTnsNB/zghTFrp11ZktiXWwVDeZBPQchBKEmo+Gx/ZhxI7Qht7YglFD4PA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/icu-messageformat-parser": "2.9.4",
-        "tslib": "2"
-      }
-    },
-    "node_modules/intl-messageformat/node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
-      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
+        "@formatjs/fast-memoize": "3.1.7",
+        "@formatjs/icu-messageformat-parser": "3.5.17"
       }
     },
     "node_modules/intl-messageformat/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz",
-      "integrity": "sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2"
-      }
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.7.tgz",
+      "integrity": "sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==",
+      "license": "MIT"
     },
     "node_modules/intl-messageformat/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.4.tgz",
-      "integrity": "sha512-Tbvp5a9IWuxUcpWNIW6GlMQYEc4rwNHR259uUFoKWNN1jM9obf9Ul0e+7r7MvFOBNcN+13K7NuKCKqQiAn1QEg==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.17.tgz",
+      "integrity": "sha512-cN9jhVqT7u0K9tix43fhjoUwL0nazyW6zsNIXs2QdPADr+nurPfYyssUiMqcSCGlPcCiqnYVxgSn7zBSuI+5Bg==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/icu-skeleton-parser": "1.8.8",
-        "tslib": "2"
+        "@formatjs/icu-skeleton-parser": "2.1.11"
       }
     },
     "node_modules/intl-messageformat/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.8.tgz",
-      "integrity": "sha512-vHwK3piXwamFcx5YQdCdJxUQ1WdTl6ANclt5xba5zLGDv5Bsur7qz8AD7BevaKxITwpgDeU0u8My3AIibW9ywA==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "tslib": "2"
-      }
-    },
-    "node_modules/intl-messageformat/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
-      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2"
-      }
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.11.tgz",
+      "integrity": "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==",
+      "license": "MIT"
     },
     "node_modules/invariant": {
       "version": "2.2.4",
@@ -13777,6 +13616,12 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.capitalize": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -16743,81 +16588,34 @@
       }
     },
     "node_modules/react-intl": {
-      "version": "6.8.9",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.8.9.tgz",
-      "integrity": "sha512-TUfj5E7lyUDvz/GtovC9OMh441kBr08rtIbgh3p0R8iF3hVY+V2W9Am7rb8BpJ/29BH1utJOqOOhmvEVh3GfZg==",
+      "version": "10.1.24",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-10.1.24.tgz",
+      "integrity": "sha512-8hiXRnnmOMEPvE5xb1T1Ce1AsmuSWX2voosCsmiyOEGEq83d1mbHy2M1DeoGKt4yF5oPPkzp+aUwSOtf+NYKPA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/icu-messageformat-parser": "2.9.4",
-        "@formatjs/intl": "2.10.15",
-        "@formatjs/intl-displaynames": "6.8.5",
-        "@formatjs/intl-listformat": "7.7.5",
-        "@types/hoist-non-react-statics": "3",
-        "@types/react": "16 || 17 || 18",
-        "hoist-non-react-statics": "3",
-        "intl-messageformat": "10.7.7",
-        "tslib": "2"
+        "@formatjs/icu-messageformat-parser": "3.5.17",
+        "@formatjs/intl": "4.1.19",
+        "intl-messageformat": "11.2.14"
       },
       "peerDependencies": {
-        "react": "^16.6.0 || 17 || 18",
-        "typescript": "^4.7 || 5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-intl/node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
-      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
-    "node_modules/react-intl/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz",
-      "integrity": "sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2"
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0"
       }
     },
     "node_modules/react-intl/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.4.tgz",
-      "integrity": "sha512-Tbvp5a9IWuxUcpWNIW6GlMQYEc4rwNHR259uUFoKWNN1jM9obf9Ul0e+7r7MvFOBNcN+13K7NuKCKqQiAn1QEg==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.17.tgz",
+      "integrity": "sha512-cN9jhVqT7u0K9tix43fhjoUwL0nazyW6zsNIXs2QdPADr+nurPfYyssUiMqcSCGlPcCiqnYVxgSn7zBSuI+5Bg==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/icu-skeleton-parser": "1.8.8",
-        "tslib": "2"
+        "@formatjs/icu-skeleton-parser": "2.1.11"
       }
     },
     "node_modules/react-intl/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.8.tgz",
-      "integrity": "sha512-vHwK3piXwamFcx5YQdCdJxUQ1WdTl6ANclt5xba5zLGDv5Bsur7qz8AD7BevaKxITwpgDeU0u8My3AIibW9ywA==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "tslib": "2"
-      }
-    },
-    "node_modules/react-intl/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
-      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2"
-      }
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.11.tgz",
+      "integrity": "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==",
+      "license": "MIT"
     },
     "node_modules/react-is": {
       "version": "18.3.1",

--- a/tutormfe/templates/mfe/build/mfe/site/package.json
+++ b/tutormfe/templates/mfe/build/mfe/site/package.json
@@ -34,16 +34,16 @@
     "{{ app['npm_package'] }}": "{{ app['npm_version'] }}",
 {%- endfor %}
 {%- if get_frontend_compat_mfes() %}
-    "@openedx/frontend-base-compat": "^1.0.0 || 0.0.0-dev",
-    "@edx/frontend-platform": "npm:@openedx/frontend-base-compat@^1.0.0 || 0.0.0-dev",
-    "@openedx/frontend-plugin-framework": "npm:@openedx/frontend-base-compat@^1.0.0 || 0.0.0-dev",
+    "@openedx/frontend-base-compat": "^2.0.0-alpha || 0.0.0-dev",
+    "@edx/frontend-platform": "npm:@openedx/frontend-base-compat@^2.0.0-alpha || 0.0.0-dev",
+    "@openedx/frontend-plugin-framework": "npm:@openedx/frontend-base-compat@^2.0.0-alpha || 0.0.0-dev",
 {%- endif %}
-    "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev"
+    "@openedx/frontend-base": "^2.0.0-alpha || 0.0.0-dev"
   },
 {%- if get_frontend_compat_mfes() %}
   "overrides": {
-    "@edx/frontend-platform": "npm:@openedx/frontend-base-compat@^1.0.0 || 0.0.0-dev",
-    "@openedx/frontend-plugin-framework": "npm:@openedx/frontend-base-compat@^1.0.0 || 0.0.0-dev"
+    "@edx/frontend-platform": "npm:@openedx/frontend-base-compat@^2.0.0-alpha || 0.0.0-dev",
+    "@openedx/frontend-plugin-framework": "npm:@openedx/frontend-base-compat@^2.0.0-alpha || 0.0.0-dev"
   },
 {%- endif %}
   "devDependencies": {

--- a/tutormfe/templates/mfe/build/mfe/site/site.config.build.tsx
+++ b/tutormfe/templates/mfe/build/mfe/site/site.config.build.tsx
@@ -18,6 +18,10 @@ import { instructorDashboardApp } from '@openedx/frontend-app-instructor-dashboa
 import { notificationsApp } from '@openedx/frontend-app-notifications';
 {% endif %}
 
+{% if get_frontend_app("catalog") %}
+import { catalogApp } from '@openedx/frontend-app-catalog';
+{% endif %}
+
 {% if get_frontend_compat_mfes() %}
 import {
   createLegacyPluginApp,
@@ -77,6 +81,10 @@ addApp(siteConfig, instructorDashboardApp);
 
 {% if get_frontend_app("notifications") %}
 addApp(siteConfig, notificationsApp);
+{% endif %}
+
+{% if get_frontend_app("catalog") %}
+addApp(siteConfig, catalogApp);
 {% endif %}
 
 {%- for mfe in iter_frontend_compat_mfes() %}

--- a/tutormfe/templates/mfe/build/mfe/site/site.config.dev.tsx
+++ b/tutormfe/templates/mfe/build/mfe/site/site.config.dev.tsx
@@ -18,6 +18,10 @@ import { instructorDashboardApp } from '@openedx/frontend-app-instructor-dashboa
 import { notificationsApp } from '@openedx/frontend-app-notifications';
 {% endif %}
 
+{% if get_frontend_app("catalog") %}
+import { catalogApp } from '@openedx/frontend-app-catalog';
+{% endif %}
+
 {% if get_frontend_compat_mfes() %}
 import {
   createLegacyPluginApp,
@@ -77,6 +81,10 @@ addApp(siteConfig, instructorDashboardApp);
 
 {% if get_frontend_app("notifications") %}
 addApp(siteConfig, notificationsApp);
+{% endif %}
+
+{% if get_frontend_app("catalog") %}
+addApp(siteConfig, catalogApp);
 {% endif %}
 
 {%- for mfe in iter_frontend_compat_mfes() %}


### PR DESCRIPTION
### Description

Move the site and the npm_version defaults to frontend-base 2.0 together.  And with all four apps on 2.0, Authn and Learner Dashboard join Instructor Dashboard and Notifications in being enabled by default.

Catalog joins them as the fifth core app, also enabled by default.

Closes openedx/frontend-app-catalog#146.

### Dependencies

This is in draft until the following is resolved, at which point the site's `package-lock.json` will need to be refreshed:

- [x]  https://github.com/openedx/frontend-base/issues/299

### LLM usage notice

Built with assistance from Claude.
