### PR TITLE
fix: build Authn, Learner Dashboard and Catalog from their legacy-mfe branches

### DIFF
--- a/changelog.d/20260828_000000_arbrandes_legacy_mfe.md
+++ b/changelog.d/20260828_000000_arbrandes_legacy_mfe.md
@@ -1,0 +1,1 @@
+- [Bugfix] Build the Authn, Learner Dashboard and Catalog micro-frontends from their `legacy-mfe` branches, which is where they live now that each repository's `master` is a frontend-base App Repository. (by @arbrandes)

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -73,6 +73,7 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
     "authn": {
         "repository": "https://github.com/openedx/frontend-app-authn.git",
         "port": 1999,
+        "version": "legacy-mfe",
     },
     "authoring": {
         "repository": "https://github.com/openedx/frontend-app-authoring.git",
@@ -97,6 +98,7 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
     "learner-dashboard": {
         "repository": "https://github.com/openedx/frontend-app-learner-dashboard.git",
         "port": 1996,
+        "version": "legacy-mfe",
     },
     "learning": {
         "repository": "https://github.com/openedx/frontend-app-learning.git",
@@ -113,6 +115,7 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
     "catalog": {
         "repository": "https://github.com/openedx/frontend-app-catalog.git",
         "port": 1998,
+        "version": "legacy-mfe",
     },
 }
 


### PR DESCRIPTION
### Description

`frontend-app-authn`, `frontend-app-learner-dashboard` and `frontend-app-catalog` have each had their long-lived `frontend-base` branch take over `master`, per [OEP-65 ADR 0004](https://docs.openedx.org/projects/openedx-proposals/en/latest/architectural-decisions/oep-0065/decisions/0004-merging-frontend-base.html). Their `master` branches are now frontend-base App Repositories and no longer build as micro-frontends. Each micro-frontend goes on living on a `legacy-mfe` branch, which is where any further `release/RELEASENAME` branches for it are cut.

This points the three `CORE_MFE_APPS` entries at that branch, so the nightly line keeps building a working micro-frontend for each. Tagged releases are unaffected, since those pin `OPENEDX_COMMON_VERSION`. The `CORE_FRONTEND_APPS` entries for all three already point at their published npm packages and need no change.

### LLM usage notice

Built with assistance from Claude.