### PR TITLE
fix: pin legacy MFE branches on master only

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,7 @@ Other MFE developers can take advantage of this plugin to deploy their own MFEs.
             "repository": "https://github.com/myorg/mymfe.git",
             "port": 2001,
             "version": "me/my-custom-branch-or-tag", # optional, will default to the Open edX current tag.
+            "alternate_master": "legacy-mfe", # optional, only applies when MFE_COMMON_VERSION is "master".
         }
         return mfes
 

--- a/changelog.d/20260828_000000_arbrandes_legacy_mfe.md
+++ b/changelog.d/20260828_000000_arbrandes_legacy_mfe.md
@@ -1,1 +1,1 @@
-- [Bugfix] Build the Authn, Learner Dashboard and Catalog micro-frontends from their `legacy-mfe` branches, which is where they live now that each repository's `master` is a frontend-base App Repository. (by @arbrandes)
+- [Bugfix] Build the Authn, Learner Dashboard and Catalog micro-frontends from their `legacy-mfe` branches when `MFE_COMMON_VERSION` is `master`. (by @arbrandes)

--- a/tutormfe/hooks.py
+++ b/tutormfe/hooks.py
@@ -38,7 +38,9 @@ FRONTEND_WIDGET_COMPAT_MAPS: Filter[list[tuple[str, dict[str, t.Any]]], []] = Fi
 # TODO(legacy-mfe-removal): MFE_ATTRS_TYPE, MFE_APPS, and PLUGIN_SLOTS all go
 # away with the legacy MFE cleanup. See the central TODO block in plugin.py for
 # the full list.
-MFE_ATTRS_TYPE = t.Dict[t.Literal["repository", "port", "version"], t.Union["str", int]]
+MFE_ATTRS_TYPE = t.Dict[
+    t.Literal["repository", "port", "version", "alternate_master"], t.Union["str", int]
+]
 
 MFE_APPS: Filter[dict[str, MFE_ATTRS_TYPE], []] = Filter()
 

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -73,7 +73,7 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
     "authn": {
         "repository": "https://github.com/openedx/frontend-app-authn.git",
         "port": 1999,
-        "version": "legacy-mfe",
+        "alternate_master": "legacy-mfe",
     },
     "authoring": {
         "repository": "https://github.com/openedx/frontend-app-authoring.git",
@@ -98,7 +98,7 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
     "learner-dashboard": {
         "repository": "https://github.com/openedx/frontend-app-learner-dashboard.git",
         "port": 1996,
-        "version": "legacy-mfe",
+        "alternate_master": "legacy-mfe",
     },
     "learning": {
         "repository": "https://github.com/openedx/frontend-app-learning.git",
@@ -115,7 +115,7 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
     "catalog": {
         "repository": "https://github.com/openedx/frontend-app-catalog.git",
         "port": 1998,
-        "version": "legacy-mfe",
+        "alternate_master": "legacy-mfe",
     },
 }
 
@@ -430,6 +430,22 @@ def get_mfe(mfe_name: str) -> t.Union[MFE_ATTRS_TYPE, t.Any]:
     return get_mfes().get(mfe_name, {})
 
 
+# TODO(legacy-mfe-removal)
+def get_mfe_version(mfe: MFE_ATTRS_TYPE, common_version: str) -> t.Any:
+    """
+    Return the git revision an MFE should be built from.
+
+    An explicit "version" always wins. "alternate_master" only applies when
+    building against master: it names the branch to build from in place of
+    master, while release builds keep following the common version.
+    """
+    if "version" in mfe:
+        return mfe["version"]
+    if common_version == "master":
+        return mfe.get("alternate_master", common_version)
+    return common_version
+
+
 def get_frontend_app(app_name: str) -> t.Union[FRONTEND_APP_ATTRS_TYPE, t.Any]:
     """
     Returns the attributes of a configured frontend app.
@@ -440,9 +456,10 @@ def get_frontend_app(app_name: str) -> t.Union[FRONTEND_APP_ATTRS_TYPE, t.Any]:
 # Make the mfe functions available within templates
 tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
     [
-        # TODO(legacy-mfe-removal): get_mfe, iter_mfes, iter_legacy_paths,
-        # iter_plugin_slots, is_mfe_enabled, MFEMountData
+        # TODO(legacy-mfe-removal): get_mfe, get_mfe_version, iter_mfes,
+        # iter_legacy_paths, iter_plugin_slots, is_mfe_enabled, MFEMountData
         ("get_mfe", get_mfe),
+        ("get_mfe_version", get_mfe_version),
         ("iter_mfes", iter_mfes),
         ("iter_legacy_paths", iter_legacy_paths),
         ("iter_frontend_apps", iter_frontend_apps),

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -32,7 +32,7 @@ ENV PATH=/openedx/app/node_modules/.bin:${PATH}
 # Empty layer with just the repo at the root, for build-time bind-mounts.
 # Cache is invalidated when the upstream commit SHA changes.
 FROM scratch AS {{ mfe_name }}-src
-ADD --keep-git-dir=true {{ mfe["repository"] }}#{{ mfe.get("version", MFE_COMMON_VERSION) }} .
+ADD --keep-git-dir=true {{ mfe["repository"] }}#{{ get_mfe_version(mfe, MFE_COMMON_VERSION) }} .
 
 ######## {{ mfe_name }} (common)
 FROM base AS {{ mfe_name }}-common


### PR DESCRIPTION
### Description

The Authn, Learner Dashboard and Catalog legacy MFEs were pinned to their `legacy-mfe` branches unconditionally, which would break release builds, where those branches do not exist. The pin now only applies when `MFE_COMMON_VERSION` is `master`, resolved at render time by a new `get_mfe_version` template helper.

Plugins can pin the same way with a new optional `legacy_master` MFE attribute. An explicit `version` still wins in all cases.

### LLM usage notice

Built with assistance from Claude.
