### PR TITLE
fix: stop deleting node_modules from bind-mounted app repos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1092,6 +1092,8 @@ You can bind-mount individual frontend app repositories for concurrent developme
 
 An ``mfe-dev`` hot-loading service will be started with the app's source bind-mounted as an npm workspace package, so changes to it are picked up automatically. The site will be available at ``http://apps.local.openedx.io:8080``.
 
+The container relies on the site's own workspace install, so the repository's local ``node_modules`` directory is hidden by a Docker volume instead of being used. It is left untouched on the host, and thus remains available to your editor, linter and test runner.
+
 You can also develop the frontend-base site locally by bind-mounting a ``frontend-site`` directory.  However, contrary to the ``frontend-app-*`` repositories, there is no upstream ``frontend-site`` equivalent. (The Open edX project considers it to be a downstream configuration concern, which is why tutor-mfe implements it internally.) There is, however, a template repository, `frontend-template-site <https://github.com/openedx/frontend-template-site>`__, you can clone locally for this purpose::
 
     git clone https://github.com/openedx/frontend-template-site.git frontend-site

--- a/changelog.d/20260901_000000_arbrandes_node_modules_volumes.md
+++ b/changelog.d/20260901_000000_arbrandes_node_modules_volumes.md
@@ -1,0 +1,1 @@
+- [Bugfix] Stop deleting the `node_modules` directory of bind-mounted frontend app repositories during development. (by @arbrandes)

--- a/tutormfe/patches/local-docker-compose-dev-services
+++ b/tutormfe/patches/local-docker-compose-dev-services
@@ -34,6 +34,9 @@ mfe-dev: # Work on the frontend site for development
         {%- for mount in site_mounts %}
         - {{ mount }}
         {%- endfor %}
+        {%- for volume in get_site_node_modules_volumes(MOUNTS) %}
+        - {{ volume }}
+        {%- endfor %}
     restart: unless-stopped
     depends_on:
         - lms

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -207,6 +207,23 @@ def get_site_mounts(mounts: list[str]) -> list[str]:
     return list(iter_mounts(mounts, SITE_MOUNT_NAME))
 
 
+def get_site_node_modules_volumes(mounts: list[str]) -> list[str]:
+    """
+    Return the container paths that need an anonymous node_modules volume in
+    the site development service.
+    """
+    volumes: list[str] = []
+    for mount in get_site_mounts(mounts):
+        # Mounts are "HOST_PATH:CONTAINER_PATH" strings, and host paths may
+        # themselves contain a colon (e.g. a Windows drive letter).
+        container_path = mount.rpartition(":")[2].rstrip("/")
+        if container_path == SITE_CONTAINER_PATH or container_path.startswith(
+            f"{SITE_PACKAGES_CONTAINER_PATH}/"
+        ):
+            volumes.append(f"{container_path}/node_modules")
+    return volumes
+
+
 # TODO(legacy-mfe-removal): get_plugin_slots / iter_plugin_slots
 @tutor_hooks.lru_cache
 def get_plugin_slots(mfe_name: str) -> list[tuple[str, str]]:
@@ -480,6 +497,7 @@ tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
         ("is_frontend_app_enabled", is_frontend_app_enabled),
         ("MFEMountData", MFEMountData),
         ("get_site_mounts", get_site_mounts),
+        ("get_site_node_modules_volumes", get_site_node_modules_volumes),
     ]
 )
 
@@ -562,6 +580,8 @@ with open(
 
 REPO_PREFIX = "frontend-app-"
 SITE_MOUNT_NAME = "frontend-site"
+SITE_CONTAINER_PATH = "/openedx/site"
+SITE_PACKAGES_CONTAINER_PATH = f"{SITE_CONTAINER_PATH}/packages"
 
 
 @tutor_hooks.Filters.COMPOSE_MOUNTS.add()
@@ -580,7 +600,7 @@ def _mount_frontend_apps(
         # frontend-site service, while legacy MFEs each have their own
         # dedicated service named after the app.
         if is_frontend_app_enabled(app_name):
-            container_path = f"/openedx/site/packages/frontend-app-{app_name}"
+            container_path = f"{SITE_PACKAGES_CONTAINER_PATH}/{REPO_PREFIX}{app_name}"
             volumes += [(SITE_MOUNT_NAME, container_path)]
         # TODO(legacy-mfe-removal): drop the elif branch
         elif is_mfe_enabled(app_name):
@@ -597,7 +617,7 @@ def _mount_site(
     in the site dev service container at /openedx/site.
     """
     if path_basename == SITE_MOUNT_NAME:
-        volumes += [(SITE_MOUNT_NAME, "/openedx/site")]
+        volumes += [(SITE_MOUNT_NAME, SITE_CONTAINER_PATH)]
     return volumes
 
 

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -112,9 +112,9 @@ COPY site/ .
 FROM base AS site-common
 WORKDIR /openedx/site
 
-# Copy frontend app packages into the workspace.
+# Copy frontend app packages into the workspace, minus any node_modules.
 {%- for app_name, app in iter_frontend_apps() %}
-COPY --from=frontend-app-{{ app_name }}-src / /openedx/site/packages/frontend-app-{{ app_name }}
+COPY --exclude=**/node_modules --from=frontend-app-{{ app_name }}-src / /openedx/site/packages/frontend-app-{{ app_name }}
 {%- endfor %}
 
 # Copy only package.json and package-lock.json first so that npm install is cached independently of source changes
@@ -126,7 +126,8 @@ RUN --mount=type=cache,target=/root/.npm,sharing=shared npm install --no-audit -
 {{ patch("mfe-dockerfile-post-npm-install-site") }}
 
 # Copy the full source; done after npm install so that source changes don't invalidate the install cache
-COPY --from=site-src / .
+# As above, minus any node_modules, which would land on top of the install we just made.
+COPY --exclude=**/node_modules --from=site-src / .
 
 RUN make ATLAS_OPTIONS="--repository={{ ATLAS_REPOSITORY }} --revision={{ ATLAS_REVISION }} {{ ATLAS_OPTIONS }}" pull_translations
 

--- a/tutormfe/templates/mfe/build/mfe/site/Makefile
+++ b/tutormfe/templates/mfe/build/mfe/site/Makefile
@@ -14,10 +14,8 @@ clean-packages:
 	$(TURBO) run clean
 
 dev-packages:
-	# Remove nested node_modules from bind-mounted packages to avoid
-	# duplicate dependency issues (e.g., two React instances).
-	find packages -maxdepth 2 -name node_modules -type d -exec rm -rf {} + 2>/dev/null || true
-	# Re-establish workspace symlinks for any bind-mounted packages.
+	# Re-establish workspace symlinks for any bind-mounted packages, and
+	# reconcile the node_modules volumes with the lockfile.
 	npm install
 	# Clean stale build artifacts from bind-mounted packages.
 	$(MAKE) clean-packages


### PR DESCRIPTION
### Description

The `mfe-dev` container used to delete a bind-mounted app repository's `node_modules` on startup, to keep duplicate dependencies out of the workspace. That deletion hit the host checkout, breaking editors, linters and test runners.

It now mounts an anonymous Docker volume over that directory instead, so the container falls back to the site's own workspace install and the host copy is left alone.

For similar reasons, the image build now excludes `node_modules` from both source copies.

### LLM usage notice

Built with assistance from Claude.
