### PR TITLE
Fix/bookworm base

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -909,6 +909,12 @@ The following Tutor configuration variables control the frontend-base site:
 - ``MFE_SITE_REPOSITORY`` (default: ``""``): an optional git URL for a custom site repository, to be used instead of the default template.
 - ``MFE_SITE_VERSION`` (default: ``""``): the branch or tag to clone from ``MFE_SITE_REPOSITORY``.
 
+The Node.js base image used to build every MFE image is also configurable:
+
+- ``MFE_NODE_IMAGE`` (default: ``docker.io/node:24.14.1-bookworm-slim``): the image the build stages start ``FROM``. Override it to pin a different Node.js release or Debian version, for instance when a base distribution reaches end of life before this plugin is updated::
+
+    tutor config save --set MFE_NODE_IMAGE=docker.io/node:24-bookworm-slim
+
 Using Frontend Slots
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/changelog.d/20260904_100000_bookworm_base.md
+++ b/changelog.d/20260904_100000_bookworm_base.md
@@ -1,0 +1,1 @@
+- [Bugfix] Build the MFE images on Debian 12 (`node:24.14.1-bookworm-slim`). Debian 11 "bullseye" left LTS on 31 August 2026 and its security packages are being removed from the mirrors, so the `apt install` in the base stage started failing with 404 errors. Bookworm is supported until mid-2028.

--- a/changelog.d/20260904_100100_node_image_setting.md
+++ b/changelog.d/20260904_100100_node_image_setting.md
@@ -1,0 +1,1 @@
+- [Feature] Add the `MFE_NODE_IMAGE` setting to choose the Node.js base image for the MFE builds, so operators can move to a different Node.js or Debian release without forking the Dockerfile.

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -42,6 +42,7 @@ config = {
         "VERSION": __version__,
         "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}overhangio/openedx-mfe:{{ MFE_VERSION }}",
         "DOCKER_IMAGE_DEV_PREFIX": "{{ DOCKER_REGISTRY }}overhangio/openedx",
+        "NODE_IMAGE": "docker.io/node:24.14.1-bookworm-slim",
         "HOST": "apps.{{ LMS_HOST }}",
         "COMMON_VERSION": "{{ OPENEDX_COMMON_VERSION }}",
         "CADDY_DOCKER_IMAGE": "{{ DOCKER_IMAGE_CADDY }}",

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # https://hub.docker.com/_/node/tags
-ARG NODE_IMAGE=docker.io/node:24.14.1-bullseye-slim
+ARG NODE_IMAGE=docker.io/node:24.14.1-bookworm-slim
 FROM $NODE_IMAGE AS base
 
 RUN apt update \

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -9,8 +9,8 @@ RUN apt update \
     gcc libgl1 libxi6 make \
     # required for gifsicle, mozjpeg, and optipng (on arm)
     autoconf libtool pkg-config zlib1g-dev \
-    # required for node-sass (on arm)
-    python g++ \
+    # required for node-gyp when native modules are compiled from source (on arm)
+    python3 python-is-python3 g++ \
     # required for image-webpack-loader (on arm)
     libpng-dev \
     # required for building node-canvas (on arm, for authoring)

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # https://hub.docker.com/_/node/tags
-ARG NODE_IMAGE=docker.io/node:24.14.1-bookworm-slim
+ARG NODE_IMAGE={{ MFE_NODE_IMAGE }}
 FROM $NODE_IMAGE AS base
 
 RUN apt update \


### PR DESCRIPTION
From 1 September 2026 MFE image builds fail in the base stage:

```
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/p/perl/libperl5.32_5.32.1-4%2bdeb11u5_amd64.deb 404 Not Found
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/x/xz-utils/xz-utils_5.2.5-2.1%7edeb11u2_amd64.deb 404 Not Found
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/g/glibc/libc-dev-bin_2.31-13%2bdeb11u14_amd64.deb 404 Not Found
...
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
ERROR: process "/bin/sh -c apt update && apt install -y git gcc libgl1 ..." did not complete successfully: exit code: 100
```

Debian 11 (bullseye) reached the end of its LTS period on 31 August 2026 and its security package pool is being removed from deb.debian.org. The Dockerfile builds on node:24.14.1-bullseye-slim, and the apt install in the base stage now hits 404s for perl, xz-utils, glibc, icu, expat and glib packages. Because that RUN comes before any patch hook, operators cannot work around it from a plugin without shadowing the whole template.

This PR is three commits:
1. Move the base image to node:24.14.1-bookworm-slim. Bookworm is supported until June 2028.
2. Install python3 and python-is-python3 instead of python. The only consumer is node-gyp; python-is-python3 keeps a bare python resolving for tooling that shells out to it.
3. Expose the base image as a Tutor setting, MFE_NODE_IMAGE. The Dockerfile already declares a NODE_IMAGE build argument but nothing lets operators set it. Documented in the README.


Testing
- make test-lint test-format test-types pass.
- Default template resolves to the bookworm image, and `tutor config save --set MFE_NODE_IMAGE=docker.io/node:24-bookworm-slim` changes the rendered ARG.
- Not tested on ARM.

Backport
The 20.x (Teak) line is affected identically and has no NODE_IMAGE argument. The first two commits apply to v20.1.0 and would unblock Teak operators; I'm happy to open that as a separate PR.